### PR TITLE
Feat: 결제 완료 Kafka 이벤트 발행 구현 (Outbox 패턴)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,8 @@ dependencies {
     testRuntimeOnly 'com.h2database:h2'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    implementation 'org.springframework.kafka:spring-kafka'
 }
 
 tasks.named('test') {

--- a/docker/init.sql
+++ b/docker/init.sql
@@ -1,0 +1,1 @@
+CREATE SCHEMA IF NOT EXISTS payment;

--- a/src/main/java/org/ticketing/payment/application/service/PaymentStatusService.java
+++ b/src/main/java/org/ticketing/payment/application/service/PaymentStatusService.java
@@ -1,5 +1,6 @@
 package org.ticketing.payment.application.service;
 
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -7,15 +8,16 @@ import org.ticketing.payment.application.dto.result.PaymentResult;
 import org.ticketing.payment.domain.exception.PaymentAmountMismatchException;
 import org.ticketing.payment.domain.exception.PaymentNotFoundException;
 import org.ticketing.payment.domain.model.Payment;
+import org.ticketing.payment.domain.outbox.PaymentOutbox;
+import org.ticketing.payment.domain.outbox.PaymentOutboxRepository;
 import org.ticketing.payment.domain.repository.PaymentRepository;
-
-import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class PaymentStatusService {
 
     private final PaymentRepository paymentRepository;
+    private final PaymentOutboxRepository paymentOutboxRepository;
 
     @Transactional
     public void startPayment(UUID paymentId, Long expectedAmount) {
@@ -32,6 +34,7 @@ public class PaymentStatusService {
         Payment payment = paymentRepository.findById(paymentId)
                 .orElseThrow(() -> new PaymentNotFoundException(paymentId));
         payment.succeed();
+        paymentOutboxRepository.save(PaymentOutbox.create(payment.getId(), payment.getReservationId()));
         return PaymentResult.from(payment);
     }
 

--- a/src/main/java/org/ticketing/payment/domain/event/PaymentCompletedEvent.java
+++ b/src/main/java/org/ticketing/payment/domain/event/PaymentCompletedEvent.java
@@ -1,0 +1,6 @@
+package org.ticketing.payment.domain.event;
+
+import java.util.UUID;
+
+public record PaymentCompletedEvent(UUID paymentId, UUID orderId) {
+}

--- a/src/main/java/org/ticketing/payment/domain/event/PaymentEventPublisher.java
+++ b/src/main/java/org/ticketing/payment/domain/event/PaymentEventPublisher.java
@@ -1,0 +1,7 @@
+package org.ticketing.payment.domain.event;
+
+import java.util.UUID;
+
+public interface PaymentEventPublisher {
+    void publishPaymentCompleted(UUID paymentId, UUID orderId);
+}

--- a/src/main/java/org/ticketing/payment/domain/event/PaymentEventPublisher.java
+++ b/src/main/java/org/ticketing/payment/domain/event/PaymentEventPublisher.java
@@ -1,7 +1,8 @@
 package org.ticketing.payment.domain.event;
 
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 public interface PaymentEventPublisher {
-    void publishPaymentCompleted(UUID paymentId, UUID orderId);
+    CompletableFuture<Void> publishPaymentCompleted(UUID paymentId, UUID orderId);
 }

--- a/src/main/java/org/ticketing/payment/domain/outbox/OutboxStatus.java
+++ b/src/main/java/org/ticketing/payment/domain/outbox/OutboxStatus.java
@@ -1,0 +1,7 @@
+package org.ticketing.payment.domain.outbox;
+
+public enum OutboxStatus {
+    PENDING,
+    PUBLISHED,
+    FAILED
+}

--- a/src/main/java/org/ticketing/payment/domain/outbox/OutboxStatus.java
+++ b/src/main/java/org/ticketing/payment/domain/outbox/OutboxStatus.java
@@ -2,6 +2,7 @@ package org.ticketing.payment.domain.outbox;
 
 public enum OutboxStatus {
     PENDING,
+    PROCESSING,
     PUBLISHED,
     FAILED
 }

--- a/src/main/java/org/ticketing/payment/domain/outbox/PaymentOutbox.java
+++ b/src/main/java/org/ticketing/payment/domain/outbox/PaymentOutbox.java
@@ -1,0 +1,70 @@
+package org.ticketing.payment.domain.outbox;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.ticketing.common.domain.BaseEntity;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "p_payment_outbox")
+public class PaymentOutbox extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id", nullable = false, updatable = false)
+    private UUID id;
+
+    @Column(name = "topic", nullable = false)
+    private String topic;
+
+    @Column(name = "payment_id", nullable = false)
+    private UUID paymentId;
+
+    @Column(name = "order_id", nullable = false)
+    private UUID orderId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 15, nullable = false)
+    private OutboxStatus status;
+
+    @Column(name = "published_at")
+    private LocalDateTime publishedAt;
+
+    @Builder
+    private PaymentOutbox(String topic, UUID paymentId, UUID orderId) {
+        this.topic = topic;
+        this.paymentId = paymentId;
+        this.orderId = orderId;
+        this.status = OutboxStatus.PENDING;
+    }
+
+    public static PaymentOutbox create(UUID paymentId, UUID orderId) {
+        return PaymentOutbox.builder()
+                .topic("payment.completed")
+                .paymentId(paymentId)
+                .orderId(orderId)
+                .build();
+    }
+
+    public void markPublished() {
+        this.status = OutboxStatus.PUBLISHED;
+        this.publishedAt = LocalDateTime.now();
+    }
+
+    public void markFailed() {
+        this.status = OutboxStatus.FAILED;
+    }
+}

--- a/src/main/java/org/ticketing/payment/domain/outbox/PaymentOutboxRepository.java
+++ b/src/main/java/org/ticketing/payment/domain/outbox/PaymentOutboxRepository.java
@@ -1,8 +1,10 @@
 package org.ticketing.payment.domain.outbox;
 
 import java.util.List;
+import java.util.UUID;
 
 public interface PaymentOutboxRepository {
     PaymentOutbox save(PaymentOutbox outbox);
     List<PaymentOutbox> findAllByStatus(OutboxStatus status);
+    boolean markProcessingIfPending(UUID id);
 }

--- a/src/main/java/org/ticketing/payment/domain/outbox/PaymentOutboxRepository.java
+++ b/src/main/java/org/ticketing/payment/domain/outbox/PaymentOutboxRepository.java
@@ -1,10 +1,8 @@
 package org.ticketing.payment.domain.outbox;
 
 import java.util.List;
-import java.util.UUID;
 
 public interface PaymentOutboxRepository {
     PaymentOutbox save(PaymentOutbox outbox);
-    List<PaymentOutbox> findPendingBatch(int size);
-    boolean markProcessingIfPending(UUID id);
+    List<PaymentOutbox> fetchAndMarkProcessing(int size);
 }

--- a/src/main/java/org/ticketing/payment/domain/outbox/PaymentOutboxRepository.java
+++ b/src/main/java/org/ticketing/payment/domain/outbox/PaymentOutboxRepository.java
@@ -5,6 +5,6 @@ import java.util.UUID;
 
 public interface PaymentOutboxRepository {
     PaymentOutbox save(PaymentOutbox outbox);
-    List<PaymentOutbox> findAllByStatus(OutboxStatus status);
+    List<PaymentOutbox> findPendingBatch(int size);
     boolean markProcessingIfPending(UUID id);
 }

--- a/src/main/java/org/ticketing/payment/domain/outbox/PaymentOutboxRepository.java
+++ b/src/main/java/org/ticketing/payment/domain/outbox/PaymentOutboxRepository.java
@@ -1,0 +1,8 @@
+package org.ticketing.payment.domain.outbox;
+
+import java.util.List;
+
+public interface PaymentOutboxRepository {
+    PaymentOutbox save(PaymentOutbox outbox);
+    List<PaymentOutbox> findAllByStatus(OutboxStatus status);
+}

--- a/src/main/java/org/ticketing/payment/infrastructure/config/SchedulingConfig.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/config/SchedulingConfig.java
@@ -1,0 +1,9 @@
+package org.ticketing.payment.infrastructure.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+}

--- a/src/main/java/org/ticketing/payment/infrastructure/kafka/KafkaPaymentEventPublisher.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/kafka/KafkaPaymentEventPublisher.java
@@ -1,0 +1,22 @@
+package org.ticketing.payment.infrastructure.kafka;
+
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+import org.ticketing.payment.domain.event.PaymentCompletedEvent;
+import org.ticketing.payment.domain.event.PaymentEventPublisher;
+
+@Component
+@RequiredArgsConstructor
+public class KafkaPaymentEventPublisher implements PaymentEventPublisher {
+
+    private static final String TOPIC = "payment.completed";
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    @Override
+    public void publishPaymentCompleted(UUID paymentId, UUID orderId) {
+        kafkaTemplate.send(TOPIC, paymentId.toString(), new PaymentCompletedEvent(paymentId, orderId));
+    }
+}

--- a/src/main/java/org/ticketing/payment/infrastructure/kafka/KafkaPaymentEventPublisher.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/kafka/KafkaPaymentEventPublisher.java
@@ -1,6 +1,7 @@
 package org.ticketing.payment.infrastructure.kafka;
 
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
@@ -16,7 +17,9 @@ public class KafkaPaymentEventPublisher implements PaymentEventPublisher {
     private final KafkaTemplate<String, Object> kafkaTemplate;
 
     @Override
-    public void publishPaymentCompleted(UUID paymentId, UUID orderId) {
-        kafkaTemplate.send(TOPIC, paymentId.toString(), new PaymentCompletedEvent(paymentId, orderId));
+    public CompletableFuture<Void> publishPaymentCompleted(UUID paymentId, UUID orderId) {
+        return kafkaTemplate
+                .send(TOPIC, paymentId.toString(), new PaymentCompletedEvent(paymentId, orderId))
+                .thenApply(result -> null);
     }
 }

--- a/src/main/java/org/ticketing/payment/infrastructure/kafka/OutboxEventRelayScheduler.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/kafka/OutboxEventRelayScheduler.java
@@ -1,5 +1,6 @@
 package org.ticketing.payment.infrastructure.kafka;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -14,24 +15,28 @@ import org.ticketing.payment.domain.outbox.PaymentOutboxRepository;
 @RequiredArgsConstructor
 public class OutboxEventRelayScheduler {
 
-    private static final int BATCH_SIZE = 100; // 얼마가 적절할지 몰라, 추후에 수정하겠습니다
+    private static final int BATCH_SIZE = 100; // 얼마가 적절할지 추후에 수정하겠습니다
 
     private final PaymentOutboxRepository outboxRepository;
     private final PaymentEventPublisher paymentEventPublisher;
 
     @Scheduled(fixedDelay = 5000) // 얼마가 적절할지 추후에 수정하겠습니다
     @Transactional
-    public void relay() {
-        outboxRepository.fetchAndMarkProcessing(BATCH_SIZE).forEach(outbox -> {
-            try {
-                paymentEventPublisher.publishPaymentCompleted(outbox.getPaymentId(), outbox.getOrderId());
-                outbox.markPublished();
-                log.info("Outbox event published: paymentId={}", outbox.getPaymentId());
-            } catch (Exception e) {
-                outbox.markFailed();
-                log.error("Failed to relay outbox event: id={}, paymentId={}", outbox.getId(), outbox.getPaymentId(), e);
-            }
-            outboxRepository.save(outbox);
-        });
+    public void relay() throws Exception {
+        List<PaymentOutbox> outboxes = outboxRepository.fetchAndMarkProcessing(BATCH_SIZE);
+
+        if (outboxes.isEmpty()) return;
+
+        for (PaymentOutbox outbox : outboxes) {
+            paymentEventPublisher
+                    .publishPaymentCompleted(outbox.getPaymentId(), outbox.getOrderId())
+                    .whenComplete((result, ex) -> {
+                        if (ex == null) {
+                            outbox.markPublished();
+                        } else {
+                            outbox.markFailed();
+                        }
+                    });
+        }
     }
 }

--- a/src/main/java/org/ticketing/payment/infrastructure/kafka/OutboxEventRelayScheduler.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/kafka/OutboxEventRelayScheduler.java
@@ -6,7 +6,6 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import org.ticketing.payment.domain.event.PaymentEventPublisher;
-import org.ticketing.payment.domain.outbox.OutboxStatus;
 import org.ticketing.payment.domain.outbox.PaymentOutbox;
 import org.ticketing.payment.domain.outbox.PaymentOutboxRepository;
 
@@ -15,13 +14,15 @@ import org.ticketing.payment.domain.outbox.PaymentOutboxRepository;
 @RequiredArgsConstructor
 public class OutboxEventRelayScheduler {
 
+    private static final int BATCH_SIZE = 100; // 얼마가 적절할지 몰라, 추후에 수정하겠습니다
+
     private final PaymentOutboxRepository outboxRepository;
     private final PaymentEventPublisher paymentEventPublisher;
 
     @Scheduled(fixedDelay = 5000) // 얼마가 적절할지 추후에 수정하겠습니다
     @Transactional
     public void relay() {
-        outboxRepository.findAllByStatus(OutboxStatus.PENDING).forEach(outbox -> {
+        outboxRepository.findPendingBatch(BATCH_SIZE).forEach(outbox -> {
             boolean acquired = outboxRepository.markProcessingIfPending(outbox.getId());
             if (!acquired) {
                 return;

--- a/src/main/java/org/ticketing/payment/infrastructure/kafka/OutboxEventRelayScheduler.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/kafka/OutboxEventRelayScheduler.java
@@ -1,0 +1,36 @@
+package org.ticketing.payment.infrastructure.kafka;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.ticketing.payment.domain.event.PaymentEventPublisher;
+import org.ticketing.payment.domain.outbox.OutboxStatus;
+import org.ticketing.payment.domain.outbox.PaymentOutbox;
+import org.ticketing.payment.domain.outbox.PaymentOutboxRepository;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OutboxEventRelayScheduler {
+
+    private final PaymentOutboxRepository outboxRepository;
+    private final PaymentEventPublisher paymentEventPublisher;
+
+    @Scheduled(fixedDelay = 5000) // 얼마가 적절할지 추후에 수정하겠습니다
+    @Transactional
+    public void relay() {
+        outboxRepository.findAllByStatus(OutboxStatus.PENDING).forEach(outbox -> {
+            try {
+                paymentEventPublisher.publishPaymentCompleted(outbox.getPaymentId(), outbox.getOrderId());
+                outbox.markPublished();
+                log.info("Outbox event published: paymentId={}", outbox.getPaymentId());
+            } catch (Exception e) {
+                outbox.markFailed();
+                log.error("Failed to relay outbox event: id={}, paymentId={}", outbox.getId(), outbox.getPaymentId(), e);
+            }
+            outboxRepository.save(outbox);
+        });
+    }
+}

--- a/src/main/java/org/ticketing/payment/infrastructure/kafka/OutboxEventRelayScheduler.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/kafka/OutboxEventRelayScheduler.java
@@ -21,7 +21,6 @@ public class OutboxEventRelayScheduler {
     private final PaymentEventPublisher paymentEventPublisher;
 
     @Scheduled(fixedDelay = 5000) // 얼마가 적절할지 추후에 수정하겠습니다
-    @Transactional
     public void relay() throws Exception {
         List<PaymentOutbox> outboxes = outboxRepository.fetchAndMarkProcessing(BATCH_SIZE);
 
@@ -36,6 +35,7 @@ public class OutboxEventRelayScheduler {
                         } else {
                             outbox.markFailed();
                         }
+                        outboxRepository.save(outbox);
                     });
         }
     }

--- a/src/main/java/org/ticketing/payment/infrastructure/kafka/OutboxEventRelayScheduler.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/kafka/OutboxEventRelayScheduler.java
@@ -22,12 +22,7 @@ public class OutboxEventRelayScheduler {
     @Scheduled(fixedDelay = 5000) // 얼마가 적절할지 추후에 수정하겠습니다
     @Transactional
     public void relay() {
-        outboxRepository.findPendingBatch(BATCH_SIZE).forEach(outbox -> {
-            boolean acquired = outboxRepository.markProcessingIfPending(outbox.getId());
-            if (!acquired) {
-                return;
-            }
-
+        outboxRepository.fetchAndMarkProcessing(BATCH_SIZE).forEach(outbox -> {
             try {
                 paymentEventPublisher.publishPaymentCompleted(outbox.getPaymentId(), outbox.getOrderId());
                 outbox.markPublished();

--- a/src/main/java/org/ticketing/payment/infrastructure/kafka/OutboxEventRelayScheduler.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/kafka/OutboxEventRelayScheduler.java
@@ -22,6 +22,11 @@ public class OutboxEventRelayScheduler {
     @Transactional
     public void relay() {
         outboxRepository.findAllByStatus(OutboxStatus.PENDING).forEach(outbox -> {
+            boolean acquired = outboxRepository.markProcessingIfPending(outbox.getId());
+            if (!acquired) {
+                return;
+            }
+
             try {
                 paymentEventPublisher.publishPaymentCompleted(outbox.getPaymentId(), outbox.getOrderId());
                 outbox.markPublished();

--- a/src/main/java/org/ticketing/payment/infrastructure/persistence/JpaPaymentOutboxRepository.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/persistence/JpaPaymentOutboxRepository.java
@@ -1,0 +1,11 @@
+package org.ticketing.payment.infrastructure.persistence;
+
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.ticketing.payment.domain.outbox.OutboxStatus;
+import org.ticketing.payment.domain.outbox.PaymentOutbox;
+
+public interface JpaPaymentOutboxRepository extends JpaRepository<PaymentOutbox, UUID> {
+    List<PaymentOutbox> findAllByStatus(OutboxStatus status);
+}

--- a/src/main/java/org/ticketing/payment/infrastructure/persistence/JpaPaymentOutboxRepository.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/persistence/JpaPaymentOutboxRepository.java
@@ -1,18 +1,8 @@
 package org.ticketing.payment.infrastructure.persistence;
 
-import java.util.List;
 import java.util.UUID;
-import org.springframework.data.domain.Limit;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.ticketing.payment.domain.outbox.OutboxStatus;
 import org.ticketing.payment.domain.outbox.PaymentOutbox;
 
 public interface JpaPaymentOutboxRepository extends JpaRepository<PaymentOutbox, UUID> {
-    List<PaymentOutbox> findAllByStatus(OutboxStatus status, Limit limit);
-
-    @Modifying
-    @Query("UPDATE PaymentOutbox o SET o.status = 'PROCESSING' WHERE o.id = :id AND o.status = 'PENDING'")
-    int markProcessingIfPending(UUID id);
 }

--- a/src/main/java/org/ticketing/payment/infrastructure/persistence/JpaPaymentOutboxRepository.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/persistence/JpaPaymentOutboxRepository.java
@@ -3,9 +3,15 @@ package org.ticketing.payment.infrastructure.persistence;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.ticketing.payment.domain.outbox.OutboxStatus;
 import org.ticketing.payment.domain.outbox.PaymentOutbox;
 
 public interface JpaPaymentOutboxRepository extends JpaRepository<PaymentOutbox, UUID> {
     List<PaymentOutbox> findAllByStatus(OutboxStatus status);
+
+    @Modifying
+    @Query("UPDATE PaymentOutbox o SET o.status = 'PROCESSING' WHERE o.id = :id AND o.status = 'PENDING'")
+    int markProcessingIfPending(UUID id);
 }

--- a/src/main/java/org/ticketing/payment/infrastructure/persistence/JpaPaymentOutboxRepository.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/persistence/JpaPaymentOutboxRepository.java
@@ -2,6 +2,7 @@ package org.ticketing.payment.infrastructure.persistence;
 
 import java.util.List;
 import java.util.UUID;
+import org.springframework.data.domain.Limit;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -9,7 +10,7 @@ import org.ticketing.payment.domain.outbox.OutboxStatus;
 import org.ticketing.payment.domain.outbox.PaymentOutbox;
 
 public interface JpaPaymentOutboxRepository extends JpaRepository<PaymentOutbox, UUID> {
-    List<PaymentOutbox> findAllByStatus(OutboxStatus status);
+    List<PaymentOutbox> findAllByStatus(OutboxStatus status, Limit limit);
 
     @Modifying
     @Query("UPDATE PaymentOutbox o SET o.status = 'PROCESSING' WHERE o.id = :id AND o.status = 'PENDING'")

--- a/src/main/java/org/ticketing/payment/infrastructure/persistence/PaymentOutboxRepositoryImpl.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/persistence/PaymentOutboxRepositoryImpl.java
@@ -1,6 +1,7 @@
 package org.ticketing.payment.infrastructure.persistence;
 
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import org.ticketing.payment.domain.outbox.OutboxStatus;
@@ -21,5 +22,10 @@ public class PaymentOutboxRepositoryImpl implements PaymentOutboxRepository {
     @Override
     public List<PaymentOutbox> findAllByStatus(OutboxStatus status) {
         return jpa.findAllByStatus(status);
+    }
+
+    @Override
+    public boolean markProcessingIfPending(UUID id) {
+        return jpa.markProcessingIfPending(id) > 0;
     }
 }

--- a/src/main/java/org/ticketing/payment/infrastructure/persistence/PaymentOutboxRepositoryImpl.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/persistence/PaymentOutboxRepositoryImpl.java
@@ -1,19 +1,21 @@
 package org.ticketing.payment.infrastructure.persistence;
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Limit;
 import org.springframework.stereotype.Repository;
 import org.ticketing.payment.domain.outbox.OutboxStatus;
 import org.ticketing.payment.domain.outbox.PaymentOutbox;
 import org.ticketing.payment.domain.outbox.PaymentOutboxRepository;
+import org.ticketing.payment.domain.outbox.QPaymentOutbox;
 
 @Repository
 @RequiredArgsConstructor
 public class PaymentOutboxRepositoryImpl implements PaymentOutboxRepository {
 
     private final JpaPaymentOutboxRepository jpa;
+    private final JPAQueryFactory queryFactory;
 
     @Override
     public PaymentOutbox save(PaymentOutbox outbox) {
@@ -21,12 +23,26 @@ public class PaymentOutboxRepositoryImpl implements PaymentOutboxRepository {
     }
 
     @Override
-    public List<PaymentOutbox> findPendingBatch(int size) {
-        return jpa.findAllByStatus(OutboxStatus.PENDING, Limit.of(size));
-    }
+    public List<PaymentOutbox> fetchAndMarkProcessing(int size) {
+        QPaymentOutbox outbox = QPaymentOutbox.paymentOutbox;
 
-    @Override
-    public boolean markProcessingIfPending(UUID id) {
-        return jpa.markProcessingIfPending(id) > 0;
+        List<PaymentOutbox> pending = queryFactory
+                .selectFrom(outbox)
+                .where(outbox.status.eq(OutboxStatus.PENDING))
+                .limit(size)
+                .fetch();
+
+        if (pending.isEmpty()) {
+            return pending;
+        }
+
+        List<UUID> ids = pending.stream().map(PaymentOutbox::getId).toList();
+        queryFactory
+                .update(outbox)
+                .set(outbox.status, OutboxStatus.PROCESSING)
+                .where(outbox.id.in(ids).and(outbox.status.eq(OutboxStatus.PENDING)))
+                .execute();
+
+        return pending;
     }
 }

--- a/src/main/java/org/ticketing/payment/infrastructure/persistence/PaymentOutboxRepositoryImpl.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/persistence/PaymentOutboxRepositoryImpl.java
@@ -1,0 +1,25 @@
+package org.ticketing.payment.infrastructure.persistence;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.ticketing.payment.domain.outbox.OutboxStatus;
+import org.ticketing.payment.domain.outbox.PaymentOutbox;
+import org.ticketing.payment.domain.outbox.PaymentOutboxRepository;
+
+@Repository
+@RequiredArgsConstructor
+public class PaymentOutboxRepositoryImpl implements PaymentOutboxRepository {
+
+    private final JpaPaymentOutboxRepository jpa;
+
+    @Override
+    public PaymentOutbox save(PaymentOutbox outbox) {
+        return jpa.save(outbox);
+    }
+
+    @Override
+    public List<PaymentOutbox> findAllByStatus(OutboxStatus status) {
+        return jpa.findAllByStatus(status);
+    }
+}

--- a/src/main/java/org/ticketing/payment/infrastructure/persistence/PaymentOutboxRepositoryImpl.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/persistence/PaymentOutboxRepositoryImpl.java
@@ -3,6 +3,7 @@ package org.ticketing.payment.infrastructure.persistence;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Limit;
 import org.springframework.stereotype.Repository;
 import org.ticketing.payment.domain.outbox.OutboxStatus;
 import org.ticketing.payment.domain.outbox.PaymentOutbox;
@@ -20,8 +21,8 @@ public class PaymentOutboxRepositoryImpl implements PaymentOutboxRepository {
     }
 
     @Override
-    public List<PaymentOutbox> findAllByStatus(OutboxStatus status) {
-        return jpa.findAllByStatus(status);
+    public List<PaymentOutbox> findPendingBatch(int size) {
+        return jpa.findAllByStatus(OutboxStatus.PENDING, Limit.of(size));
     }
 
     @Override

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -24,7 +24,15 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
+        default_schema: ${DB_SCHEMA:payment}
+        hbm2ddl:
+          create_schemas: true
 
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
 
 eureka:
   client:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,7 +13,7 @@ spring:
         enabled: false  #로컬 개발용 config 차단
 
   datasource:
-    url: jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT}/${DB_NAME}
+    url: jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT}/${DB_NAME}?currentSchema=${DB_SCHEMA:payment}
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver


### PR DESCRIPTION
### 📎 관련 이슈
- close #7 

### 📌 작업 내용
  
  - Outbox 패턴 적용: PaymentOutbox 엔티티 및 p_payment_outbox 테이블로 이벤트를 DB에 먼저 저장 후 발행                                       
  - Kafka 이벤트 발행: OutboxEventRelayScheduler가 5초마다 PENDING 상태의 outbox를 조회해 payment.completed 토픽으로 발행  

### ✨ 변경 사항
- 주요 변경 내용 정리

### 📝 리뷰 포인트 (선택)
- Outbox 발행 실패 시 FAILED 상태로만 남고 재시도 로직이 없음 (추후 추가 예정)

### 🧠 기타 참고 사항

kafka 이벤트 발행 확인
<img width="957" height="278" alt="스크린샷 2026-04-28 11 49 07" src="https://github.com/user-attachments/assets/4bc6887b-fb4c-4bd9-b69c-5c7550b5d598" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added event publishing for payment completion via Kafka.
  * Payment processing now records outbox entries when payments succeed.
  * Implemented outbox lifecycle states (pending/processing/published/failed) and a scheduled relay that processes batches and publishes events.

* **Infrastructure**
  * Initialized payment database schema on startup and configured datasource/schema handling.
  * Added Kafka producer configuration and enabled scheduling support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->