### PR TITLE
Feat: Customer/Internal 결제 조회 API 구현

### DIFF
--- a/src/main/java/org/ticketing/payment/application/service/PaymentService.java
+++ b/src/main/java/org/ticketing/payment/application/service/PaymentService.java
@@ -49,6 +49,23 @@ public class PaymentService {
         return paymentRepository.findAll(pageable).map(PaymentResult::from);
     }
 
+    @Transactional(readOnly = true)
+    public Page<PaymentResult> getPaymentsByReservationId(UUID reservationId, Pageable pageable) {
+        return paymentRepository.findByReservationId(reservationId, pageable).map(PaymentResult::from);
+    }
+
+    @Transactional(readOnly = true)
+    public PaymentResult getSuccessPaymentByReservationId(UUID reservationId) {
+        Payment payment = paymentRepository.findSuccessPaymentByReservationId(reservationId)
+                .orElseThrow(() -> new PaymentNotFoundException(reservationId));
+        return PaymentResult.from(payment);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<PaymentResult> getPaymentsByUserId(UUID userId, Pageable pageable) {
+        return paymentRepository.findByUserId(userId, pageable).map(PaymentResult::from);
+    }
+
     @Transactional
     public PaymentResult cancelPayment(UUID paymentId) {
         Payment payment = paymentRepository.findById(paymentId)

--- a/src/main/java/org/ticketing/payment/domain/repository/PaymentRepository.java
+++ b/src/main/java/org/ticketing/payment/domain/repository/PaymentRepository.java
@@ -12,4 +12,7 @@ public interface PaymentRepository {
     Optional<Payment> findById(UUID id);
     Page<Payment> findAll(Pageable pageable);
     boolean existsActivePayment(UUID reservationId);
+    Page<Payment> findByReservationId(UUID reservationId, Pageable pageable);
+    Optional<Payment> findSuccessPaymentByReservationId(UUID reservationId);
+    Page<Payment> findByUserId(UUID userId, Pageable pageable);
 }

--- a/src/main/java/org/ticketing/payment/infrastructure/persistence/JpaPaymentRepository.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/persistence/JpaPaymentRepository.java
@@ -14,4 +14,7 @@ public interface JpaPaymentRepository extends JpaRepository<Payment, UUID> {
     Optional<Payment> findByIdAndDeletedAtIsNull(UUID id);
     Page<Payment> findAllByDeletedAtIsNull(Pageable pageable);
     boolean existsByReservationIdAndStatusIn(UUID reservationId, List<PaymentStatus> statuses);
+    Page<Payment> findByReservationIdAndDeletedAtIsNull(UUID reservationId, Pageable pageable);
+    Optional<Payment> findByReservationIdAndStatusAndDeletedAtIsNull(UUID reservationId, PaymentStatus status);
+    Page<Payment> findByUserIdAndDeletedAtIsNull(UUID userId, Pageable pageable);
 }

--- a/src/main/java/org/ticketing/payment/infrastructure/persistence/JpaPaymentRepository.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/persistence/JpaPaymentRepository.java
@@ -15,6 +15,6 @@ public interface JpaPaymentRepository extends JpaRepository<Payment, UUID> {
     Page<Payment> findAllByDeletedAtIsNull(Pageable pageable);
     boolean existsByReservationIdAndStatusIn(UUID reservationId, List<PaymentStatus> statuses);
     Page<Payment> findByReservationIdAndDeletedAtIsNull(UUID reservationId, Pageable pageable);
-    Optional<Payment> findByReservationIdAndStatusAndDeletedAtIsNull(UUID reservationId, PaymentStatus status);
+    Optional<Payment> findFirstByReservationIdAndStatusAndDeletedAtIsNullOrderByCreatedAtDesc(UUID reservationId, PaymentStatus status);
     Page<Payment> findByUserIdAndDeletedAtIsNull(UUID userId, Pageable pageable);
 }

--- a/src/main/java/org/ticketing/payment/infrastructure/persistence/PaymentRepositoryImpl.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/persistence/PaymentRepositoryImpl.java
@@ -45,7 +45,7 @@ public class PaymentRepositoryImpl implements PaymentRepository {
 
     @Override
     public Optional<Payment> findSuccessPaymentByReservationId(UUID reservationId) {
-        return jpaPaymentRepository.findByReservationIdAndStatusAndDeletedAtIsNull(reservationId, PaymentStatus.SUCCESS);
+        return jpaPaymentRepository.findFirstByReservationIdAndStatusAndDeletedAtIsNullOrderByCreatedAtDesc(reservationId, PaymentStatus.SUCCESS);
     }
 
     @Override

--- a/src/main/java/org/ticketing/payment/infrastructure/persistence/PaymentRepositoryImpl.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/persistence/PaymentRepositoryImpl.java
@@ -37,4 +37,19 @@ public class PaymentRepositoryImpl implements PaymentRepository {
         return jpaPaymentRepository.existsByReservationIdAndStatusIn(
                 reservationId, List.of(PaymentStatus.INIT, PaymentStatus.IN_PROGRESS));
     }
+
+    @Override
+    public Page<Payment> findByReservationId(UUID reservationId, Pageable pageable) {
+        return jpaPaymentRepository.findByReservationIdAndDeletedAtIsNull(reservationId, pageable);
+    }
+
+    @Override
+    public Optional<Payment> findSuccessPaymentByReservationId(UUID reservationId) {
+        return jpaPaymentRepository.findByReservationIdAndStatusAndDeletedAtIsNull(reservationId, PaymentStatus.SUCCESS);
+    }
+
+    @Override
+    public Page<Payment> findByUserId(UUID userId, Pageable pageable) {
+        return jpaPaymentRepository.findByUserIdAndDeletedAtIsNull(userId, pageable);
+    }
 }

--- a/src/main/java/org/ticketing/payment/presentation/controller/PaymentController.java
+++ b/src/main/java/org/ticketing/payment/presentation/controller/PaymentController.java
@@ -60,7 +60,7 @@ public class PaymentController {
         return PaymentResponseDto.from(paymentService.getPayment(paymentId));
     }
 
-    // reservationId에 따른 결제 정보 조회 [Amdin]
+    // reservationId에 따른 결제 정보 조회 [Admin]
     @GetMapping("/reservations/{reservationId}")
     public Page<PaymentResponseDto> getPaymentsByReservationId(
             @PathVariable @NotNull UUID reservationId,

--- a/src/main/java/org/ticketing/payment/presentation/controller/PaymentController.java
+++ b/src/main/java/org/ticketing/payment/presentation/controller/PaymentController.java
@@ -27,16 +27,48 @@ public class PaymentController {
 
     private final PaymentService paymentService;
 
+    // 결제 시도 생성 [Customer]
+    // (사용자가 결제 요청 버튼 누를 때)
     @PostMapping
     public PaymentResponseDto createPayment(@RequestBody @Valid CreatePaymentRequestDto request) {
         return PaymentResponseDto.from(paymentService.createPayment(request.toCommand()));
     }
 
+    // paymentId에 따른 결제 정보 조회 [Customer]
+    @GetMapping("/my/{paymentId}")
+    public PaymentResponseDto getMyPayment(@PathVariable @NotNull UUID paymentId) {
+        return PaymentResponseDto.from(paymentService.getPayment(paymentId));
+    }
+
+    // reservationId에 따른 결제 정보 조회 [Customer]
+    @GetMapping("/my/reservations/{reservationId}")
+    public Page<PaymentResponseDto> getMyPaymentsByReservationId(
+            @PathVariable @NotNull UUID reservationId,
+            @PageableDefault(size = 10, sort = "createdAt") Pageable pageable) {
+        return paymentService.getPaymentsByReservationId(reservationId, pageable).map(PaymentResponseDto::from);
+    }
+
+    // reservationId에 따른 성공 결제 정보 조회 [Customer]
+    @GetMapping("/my/reservations/{reservationId}/success")
+    public PaymentResponseDto getMySuccessPaymentByReservationId(@PathVariable @NotNull UUID reservationId) {
+        return PaymentResponseDto.from(paymentService.getSuccessPaymentByReservationId(reservationId));
+    }
+
+    // paymentId에 따른 결제 정보 조회 [Admin]
     @GetMapping("/{paymentId}")
     public PaymentResponseDto getPayment(@PathVariable @NotNull UUID paymentId) {
         return PaymentResponseDto.from(paymentService.getPayment(paymentId));
     }
 
+    // reservationId에 따른 결제 정보 조회 [Amdin]
+    @GetMapping("/reservations/{reservationId}")
+    public Page<PaymentResponseDto> getPaymentsByReservationId(
+            @PathVariable @NotNull UUID reservationId,
+            @PageableDefault(size = 10, sort = "createdAt") Pageable pageable) {
+        return paymentService.getPaymentsByReservationId(reservationId, pageable).map(PaymentResponseDto::from);
+    }
+
+    // 전체 결제 정보 조회 [Admin]
     @GetMapping
     public Page<PaymentResponseDto> getPayments(
             @PageableDefault(size = 10, sort = "createdAt") Pageable pageable) {
@@ -48,6 +80,7 @@ public class PaymentController {
         return PaymentResponseDto.from(paymentService.cancelPayment(paymentId));
     }
 
+    // 결제 승인 [PG]
     @PostMapping("/success")
     public PaymentResponseDto confirmPayment(
             @RequestBody @Valid PaymentSuccessRequestDto request) {

--- a/src/main/java/org/ticketing/payment/presentation/controller/PaymentInternalController.java
+++ b/src/main/java/org/ticketing/payment/presentation/controller/PaymentInternalController.java
@@ -1,22 +1,15 @@
 package org.ticketing.payment.presentation.controller;
 
-
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.ticketing.payment.application.service.PaymentService;
-import org.ticketing.payment.presentation.dto.request.CreatePaymentRequestDto;
-import org.ticketing.payment.presentation.dto.request.PaymentSuccessRequestDto;
 import org.ticketing.payment.presentation.dto.response.PaymentResponseDto;
 
 import java.util.UUID;
@@ -28,19 +21,31 @@ public class PaymentInternalController {
 
     private final PaymentService paymentService;
 
-    @PostMapping
-    public PaymentResponseDto createPayment(@RequestBody @Valid CreatePaymentRequestDto request) {
-        return PaymentResponseDto.from(paymentService.createPayment(request.toCommand()));
+    // userId에 따른 결제 정보 조회
+    @GetMapping("/users/{userId}")
+    public Page<PaymentResponseDto> getPaymentsByUserId(
+            @PathVariable @NotNull UUID userId,
+            @PageableDefault(size = 10, sort = "createdAt") Pageable pageable) {
+        return paymentService.getPaymentsByUserId(userId, pageable).map(PaymentResponseDto::from);
     }
 
+    // paymentId에 따른 결제 정보 조회
     @GetMapping("/{paymentId}")
     public PaymentResponseDto getPayment(@PathVariable @NotNull UUID paymentId) {
         return PaymentResponseDto.from(paymentService.getPayment(paymentId));
     }
 
-    @GetMapping
-    public Page<PaymentResponseDto> getPayments(
+    // reservationId에 따른 결제 정보 조회 (성공, 실패 등등 모든 시도 포함)
+    @GetMapping("/reservations/{reservationId}")
+    public Page<PaymentResponseDto> getPaymentsByReservationId(
+            @PathVariable @NotNull UUID reservationId,
             @PageableDefault(size = 10, sort = "createdAt") Pageable pageable) {
-        return paymentService.getPayments(pageable).map(PaymentResponseDto::from);
+        return paymentService.getPaymentsByReservationId(reservationId, pageable).map(PaymentResponseDto::from);
+    }
+
+    // reservationId에 따른 성공 결제 정보 조회
+    @GetMapping("/reservations/{reservationId}/success")
+    public PaymentResponseDto getSuccessPaymentByReservationId(@PathVariable @NotNull UUID reservationId) {
+        return PaymentResponseDto.from(paymentService.getSuccessPaymentByReservationId(reservationId));
     }
 }


### PR DESCRIPTION
### 📎 관련 이슈
- close #10 

### 📌 작업 내용
결제 조회 API 중 미구현 상태였던 엔드포인트를 추가했습니다.           
  **Customer (`/api/payments/my`)**
  - `GET /api/payments/my/{paymentId}` — 내 결제 단건 조회              
  - `GET /api/payments/my/reservations/{reservationId}` — 내 예약 전체  결제 목록 조회                                                        
  - `GET /api/payments/my/reservations/{reservationId}/success` — 내 예약 성공 결제 단건 조회                                              
                  
  **Admin (`/api/payments`)**                                           
  - `GET /api/payments/{paymentId}` — 결제 단건 조회
  - `GET /api/payments/reservations/{reservationId}` — 예약 전체 결제 목록 조회                                                             
   
  **Internal (`/internal/payments`)**                                   
  - `GET /internal/payments/users/{userId}` — 유저 ID로 결제 목록 조회
  - `GET /internal/payments/reservations/{reservationId}` — 예약 ID로 전체 결제 목록 조회                                                   
  - `GET /internal/payments/reservations/{reservationId}/success` — 예약 ID로 성공 결제 단건 조회  

### 🧠 기타 참고 사항 
- 실제 userId에 따른 인증은 추후에 진행 예정