### PR TITLE
Feat: 결제 FAILED 이벤트

### DIFF
--- a/src/main/java/org/ticketing/payment/application/service/PaymentStatusService.java
+++ b/src/main/java/org/ticketing/payment/application/service/PaymentStatusService.java
@@ -43,6 +43,7 @@ public class PaymentStatusService {
         Payment payment = paymentRepository.findById(paymentId)
                 .orElseThrow(() -> new PaymentNotFoundException(paymentId));
         payment.fail();
+        paymentOutboxRepository.save(PaymentOutbox.createFailed(payment.getId(), payment.getReservationId()));
         return PaymentResult.from(payment);
     }
 

--- a/src/main/java/org/ticketing/payment/domain/event/PaymentEventPublisher.java
+++ b/src/main/java/org/ticketing/payment/domain/event/PaymentEventPublisher.java
@@ -5,5 +5,6 @@ import java.util.concurrent.CompletableFuture;
 
 public interface PaymentEventPublisher {
     CompletableFuture<Void> publishPaymentCompleted(UUID paymentId, UUID orderId);
+    CompletableFuture<Void> publishPaymentFailed(UUID paymentId, UUID orderId);
     CompletableFuture<Void> publishPaymentRefunded(UUID paymentId, UUID orderId);
 }

--- a/src/main/java/org/ticketing/payment/domain/event/PaymentFailedEvent.java
+++ b/src/main/java/org/ticketing/payment/domain/event/PaymentFailedEvent.java
@@ -1,0 +1,6 @@
+package org.ticketing.payment.domain.event;
+
+import java.util.UUID;
+
+public record PaymentFailedEvent(UUID paymentId, UUID orderId) {
+}

--- a/src/main/java/org/ticketing/payment/domain/outbox/PaymentOutbox.java
+++ b/src/main/java/org/ticketing/payment/domain/outbox/PaymentOutbox.java
@@ -59,6 +59,14 @@ public class PaymentOutbox extends BaseEntity {
                 .build();
     }
 
+    public static PaymentOutbox createFailed(UUID paymentId, UUID orderId) {
+        return PaymentOutbox.builder()
+                .topic("payment.failed")
+                .paymentId(paymentId)
+                .orderId(orderId)
+                .build();
+    }
+
     public static PaymentOutbox createRefund(UUID paymentId, UUID orderId) {
         return PaymentOutbox.builder()
                 .topic("payment.refunded")

--- a/src/main/java/org/ticketing/payment/infrastructure/kafka/KafkaPaymentEventPublisher.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/kafka/KafkaPaymentEventPublisher.java
@@ -7,6 +7,7 @@ import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 import org.ticketing.payment.domain.event.PaymentCompletedEvent;
 import org.ticketing.payment.domain.event.PaymentEventPublisher;
+import org.ticketing.payment.domain.event.PaymentFailedEvent;
 import org.ticketing.payment.domain.event.PaymentRefundedEvent;
 
 @Component
@@ -15,6 +16,7 @@ public class KafkaPaymentEventPublisher implements PaymentEventPublisher {
 
     private static final String TOPIC_COMPLETED = "payment.completed";
     private static final String TOPIC_REFUNDED  = "payment.refunded";
+    private static final String TOPIC_FAILED    = "payment.failed";
 
     private final KafkaTemplate<String, Object> kafkaTemplate;
 
@@ -29,6 +31,13 @@ public class KafkaPaymentEventPublisher implements PaymentEventPublisher {
     public CompletableFuture<Void> publishPaymentRefunded(UUID paymentId, UUID orderId) {
         return kafkaTemplate
                 .send(TOPIC_REFUNDED, paymentId.toString(), new PaymentRefundedEvent(paymentId, orderId))
+                .thenApply(result -> null);
+    }
+
+    @Override
+    public CompletableFuture<Void> publishPaymentFailed(UUID paymentId, UUID orderId) {
+        return kafkaTemplate
+                .send(TOPIC_FAILED, paymentId.toString(), new PaymentFailedEvent(paymentId, orderId))
                 .thenApply(result -> null);
     }
 }

--- a/src/main/java/org/ticketing/payment/infrastructure/kafka/OutboxEventRelayScheduler.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/kafka/OutboxEventRelayScheduler.java
@@ -44,6 +44,7 @@ public class OutboxEventRelayScheduler {
         UUID orderId   = outbox.getOrderId();
         return switch (outbox.getTopic()) {
             case "payment.completed" -> paymentEventPublisher.publishPaymentCompleted(paymentId, orderId);
+            case "payment.failed"    -> paymentEventPublisher.publishPaymentFailed(paymentId, orderId);
             case "payment.refunded"  -> paymentEventPublisher.publishPaymentRefunded(paymentId, orderId);
             default -> CompletableFuture.failedFuture(
                     new IllegalStateException("알 수 없는 outbox 토픽: " + outbox.getTopic()));


### PR DESCRIPTION
### 📎 관련 이슈
- close #13 

###📌 작업 내용
                                                                            
- 결제 실패(FAILED) 시 Kafka 이벤트를 발행하는 기능 구현
- 기존 결제 완료/환불 이벤트와 동일하게 Outbox 패턴 적용                  
                                                                            
###✨ 변경 사항
                                                                            
- PaymentFailedEvent 레코드 클래스 추가 (paymentId, orderId)              
- PaymentEventPublisher 인터페이스에 publishPaymentFailed 메서드 추가
- KafkaPaymentEventPublisher에 payment.failed 토픽으로 이벤트 발행 구현   
- PaymentOutbox.createFailed() 팩토리 메서드 추가                         
- PaymentStatusService.fail() 호출 시 Outbox 레코드 저장 추가             
- OutboxEventRelayScheduler 스위치에 payment.failed 케이스 추가           
                                                                            
###📝 리뷰 포인트 (선택)                                                     
                                                                            
- payment.completed / payment.refunded / payment.failed 토픽명
                                                                            
###🧠 기타 참고 사항                                                         
                                              
                  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Payment failure events are now reliably published and tracked through the event system, ensuring failed transactions are handled consistently with successful payments and refunds across all services.

* **Infrastructure Updates**
  * Enhanced event infrastructure to support payment failure event propagation through the messaging system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->