### PR TITLE
Test: payment, paymentStatus 도메인 테스트 및 단위 테스트

### DIFF
--- a/src/main/java/org/ticketing/payment/application/service/PaymentService.java
+++ b/src/main/java/org/ticketing/payment/application/service/PaymentService.java
@@ -30,6 +30,10 @@ public class PaymentService {
 
     @Transactional
     public PaymentResult createPayment(CreatePaymentCommand command) {
+
+        // Todo: [Feign] Reservation reservationId에 대한 reservation 정보 대조 (totalPrice, userId)
+        // Todo: [Feign] Reservation 해당 예약 상태가 PENDING인지 & 좌석 상태가 HOLD인지 확인
+
         if (paymentRepository.existsActivePayment(command.getReservationId())) {
             throw new DuplicatePaymentException(command.getReservationId());
         }

--- a/src/main/java/org/ticketing/payment/application/service/PaymentStatusService.java
+++ b/src/main/java/org/ticketing/payment/application/service/PaymentStatusService.java
@@ -8,8 +8,11 @@ import org.ticketing.payment.application.dto.result.PaymentResult;
 import org.ticketing.payment.domain.exception.PaymentAmountMismatchException;
 import org.ticketing.payment.domain.exception.PaymentNotFoundException;
 import org.ticketing.payment.domain.model.Payment;
+import org.ticketing.payment.domain.model.PaymentLog;
+import org.ticketing.payment.domain.model.PaymentStatus;
 import org.ticketing.payment.domain.outbox.PaymentOutbox;
 import org.ticketing.payment.domain.outbox.PaymentOutboxRepository;
+import org.ticketing.payment.domain.repository.PaymentLogRepository;
 import org.ticketing.payment.domain.repository.PaymentRepository;
 
 @Service
@@ -18,6 +21,7 @@ public class PaymentStatusService {
 
     private final PaymentRepository paymentRepository;
     private final PaymentOutboxRepository paymentOutboxRepository;
+    private final PaymentLogRepository paymentLogRepository;
 
     @Transactional
     public void startPayment(UUID paymentId, Long expectedAmount) {
@@ -26,14 +30,18 @@ public class PaymentStatusService {
         if (!payment.getTotalPrice().equals(expectedAmount)) {
             throw new PaymentAmountMismatchException(payment.getTotalPrice(), expectedAmount);
         }
+        PaymentStatus fromStatus = payment.getStatus();
         payment.start();
+        paymentLogRepository.save(PaymentLog.create(payment.getId(), fromStatus, payment.getStatus()));
     }
 
     @Transactional
     public PaymentResult succeedPayment(UUID paymentId, String paymentKey) {
         Payment payment = paymentRepository.findById(paymentId)
                 .orElseThrow(() -> new PaymentNotFoundException(paymentId));
+        PaymentStatus fromStatus = payment.getStatus();
         payment.succeed(paymentKey);
+        paymentLogRepository.save(PaymentLog.create(payment.getId(), fromStatus, payment.getStatus()));
         paymentOutboxRepository.save(PaymentOutbox.createCompleted(payment.getId(), payment.getReservationId()));
         return PaymentResult.from(payment);
     }
@@ -42,7 +50,9 @@ public class PaymentStatusService {
     public PaymentResult failPayment(UUID paymentId) {
         Payment payment = paymentRepository.findById(paymentId)
                 .orElseThrow(() -> new PaymentNotFoundException(paymentId));
+        PaymentStatus fromStatus = payment.getStatus();
         payment.fail();
+        paymentLogRepository.save(PaymentLog.create(payment.getId(), fromStatus, payment.getStatus()));
         paymentOutboxRepository.save(PaymentOutbox.createFailed(payment.getId(), payment.getReservationId()));
         return PaymentResult.from(payment);
     }
@@ -51,7 +61,9 @@ public class PaymentStatusService {
     public Payment startRefund(UUID reservationId) {
         Payment payment = paymentRepository.findSuccessPaymentByReservationId(reservationId)
                 .orElseThrow(() -> new PaymentNotFoundException(reservationId));
+        PaymentStatus fromStatus = payment.getStatus();
         payment.startRefund();
+        paymentLogRepository.save(PaymentLog.create(payment.getId(), fromStatus, payment.getStatus()));
         return payment;
     }
 
@@ -59,7 +71,9 @@ public class PaymentStatusService {
     public PaymentResult refundPayment(UUID paymentId) {
         Payment payment = paymentRepository.findById(paymentId)
                 .orElseThrow(() -> new PaymentNotFoundException(paymentId));
+        PaymentStatus fromStatus = payment.getStatus();
         payment.refund();
+        paymentLogRepository.save(PaymentLog.create(payment.getId(), fromStatus, payment.getStatus()));
         paymentOutboxRepository.save(PaymentOutbox.createRefund(payment.getId(), payment.getReservationId()));
         return PaymentResult.from(payment);
     }

--- a/src/main/java/org/ticketing/payment/domain/model/PaymentLog.java
+++ b/src/main/java/org/ticketing/payment/domain/model/PaymentLog.java
@@ -38,9 +38,17 @@ public class PaymentLog {
     private PaymentStatus toStatus;
 
     @Builder
-    public PaymentLog(UUID paymentId, PaymentStatus fromStatus, PaymentStatus toStatus) {
+    private PaymentLog(UUID paymentId, PaymentStatus fromStatus, PaymentStatus toStatus) {
         this.paymentId = paymentId;
         this.fromStatus = fromStatus;
         this.toStatus = toStatus;
+    }
+
+    public static PaymentLog create(UUID paymentId, PaymentStatus fromStatus, PaymentStatus toStatus) {
+        return PaymentLog.builder()
+                .paymentId(paymentId)
+                .fromStatus(fromStatus)
+                .toStatus(toStatus)
+                .build();
     }
 }

--- a/src/main/java/org/ticketing/payment/domain/model/PaymentStatus.java
+++ b/src/main/java/org/ticketing/payment/domain/model/PaymentStatus.java
@@ -15,7 +15,7 @@ public enum PaymentStatus {
 
     private static final Map<PaymentStatus, Set<PaymentStatus>> ALLOWED = Map.of(
             INIT,        EnumSet.of(PAYING, EXPIRED),
-            PAYING, EnumSet.of(SUCCESS, FAIL, REFUNDING, EXPIRED),
+            PAYING, EnumSet.of(SUCCESS, FAIL, EXPIRED),
             SUCCESS,     EnumSet.of(REFUNDING, FAIL, EXPIRED),
             FAIL,      EnumSet.noneOf(PaymentStatus.class),
             REFUNDING, EnumSet.of(REFUNDED, SUCCESS, FAIL, EXPIRED),

--- a/src/main/java/org/ticketing/payment/domain/repository/PaymentLogRepository.java
+++ b/src/main/java/org/ticketing/payment/domain/repository/PaymentLogRepository.java
@@ -1,0 +1,7 @@
+package org.ticketing.payment.domain.repository;
+
+import org.ticketing.payment.domain.model.PaymentLog;
+
+public interface PaymentLogRepository {
+    PaymentLog save(PaymentLog paymentLog);
+}

--- a/src/main/java/org/ticketing/payment/infrastructure/persistence/JpaPaymentLogRepository.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/persistence/JpaPaymentLogRepository.java
@@ -1,0 +1,8 @@
+package org.ticketing.payment.infrastructure.persistence;
+
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.ticketing.payment.domain.model.PaymentLog;
+
+public interface JpaPaymentLogRepository extends JpaRepository<PaymentLog, UUID> {
+}

--- a/src/main/java/org/ticketing/payment/infrastructure/persistence/PaymentLogRepositoryImpl.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/persistence/PaymentLogRepositoryImpl.java
@@ -1,0 +1,17 @@
+package org.ticketing.payment.infrastructure.persistence;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.ticketing.payment.domain.model.PaymentLog;
+import org.ticketing.payment.domain.repository.PaymentLogRepository;
+
+@Repository
+@RequiredArgsConstructor
+public class PaymentLogRepositoryImpl implements PaymentLogRepository {
+    private final JpaPaymentLogRepository jpaPaymentLogRepository;
+
+    @Override
+    public PaymentLog save(PaymentLog paymentLog) {
+        return jpaPaymentLogRepository.save(paymentLog);
+    }
+}

--- a/src/main/java/org/ticketing/payment/infrastructure/toss/TossPaymentClient.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/toss/TossPaymentClient.java
@@ -18,8 +18,6 @@ import org.ticketing.payment.infrastructure.toss.dto.TossPaymentStatusResponse;
 @RequiredArgsConstructor
 public class TossPaymentClient {
 
-    private static final String TOSS_BASE_URL = "https://api.tosspayments.com";
-
     private final TossPaymentProperties properties;
 
     public TossConfirmResponse confirm(String paymentKey, String orderId, Long amount) {
@@ -27,7 +25,7 @@ public class TossPaymentClient {
                 .encodeToString((properties.getSecretKey() + ":").getBytes(StandardCharsets.UTF_8));
 
         return RestClient.builder()
-                .baseUrl(TOSS_BASE_URL)
+                .baseUrl(properties.getBaseUrl())
                 .build()
                 .post()
                 .uri("/v1/payments/confirm")
@@ -50,7 +48,7 @@ public class TossPaymentClient {
                 .encodeToString((properties.getSecretKey() + ":").getBytes(StandardCharsets.UTF_8));
 
         return RestClient.builder()
-                .baseUrl(TOSS_BASE_URL)
+                .baseUrl(properties.getBaseUrl())
                 .build()
                 .post()
                 .uri("/v1/payments/{paymentKey}/cancel", paymentKey)
@@ -74,7 +72,7 @@ public class TossPaymentClient {
                 .encodeToString((properties.getSecretKey() + ":").getBytes(StandardCharsets.UTF_8));
 
         return RestClient.builder()
-                .baseUrl(TOSS_BASE_URL)
+                .baseUrl(properties.getBaseUrl())
                 .build()
                 .get()
                 .uri("/v1/payments/orders/{orderId}", orderId)
@@ -88,7 +86,7 @@ public class TossPaymentClient {
                 .encodeToString((properties.getSecretKey() + ":").getBytes(StandardCharsets.UTF_8));
 
         return RestClient.builder()
-                .baseUrl(TOSS_BASE_URL)
+                .baseUrl(properties.getBaseUrl())
                 .build()
                 .get()
                 .uri("/v1/payments/{paymentKey}", paymentKey)

--- a/src/main/java/org/ticketing/payment/infrastructure/toss/TossPaymentProperties.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/toss/TossPaymentProperties.java
@@ -12,4 +12,5 @@ import org.springframework.stereotype.Component;
 public class TossPaymentProperties {
 
     private String secretKey;
+    private String baseUrl = "https://api.tosspayments.com";
 }

--- a/src/main/java/org/ticketing/payment/presentation/advice/PaymentControllerAdvice.java
+++ b/src/main/java/org/ticketing/payment/presentation/advice/PaymentControllerAdvice.java
@@ -38,8 +38,12 @@ public class PaymentControllerAdvice {
 
     @ExceptionHandler(DataIntegrityViolationException.class)
     public ResponseEntity<Map<String, Object>> handleDataIntegrityViolation(DataIntegrityViolationException ex) {
-        log.warn("DataIntegrityViolation (concurrent duplicate payment): {}", ex.getMostSpecificCause().getMessage());
-        return errorResponse(HttpStatus.CONFLICT, "Active payment already exists for this reservation");
+        String cause = ex.getMostSpecificCause().getMessage();
+        log.warn("DataIntegrityViolation: {}", cause);
+        if (cause != null && cause.toLowerCase().contains("unique")) {
+            return errorResponse(HttpStatus.CONFLICT, "Active payment already exists for this reservation");
+        }
+        return errorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "A database integrity error occurred");
     }
 
     @ExceptionHandler(InvalidPaymentStatusTransitionException.class)
@@ -65,13 +69,13 @@ public class PaymentControllerAdvice {
     @ExceptionHandler(TossPaymentConfirmException.class)
     public ResponseEntity<Map<String, Object>> handleTossConfirmFail(TossPaymentConfirmException ex) {
         log.error("Toss confirm failed: {}", ex.getMessage());
-        return errorResponse(HttpStatus.BAD_GATEWAY, ex.getMessage());
+        return errorResponse(HttpStatus.BAD_GATEWAY, "Payment confirmation failed due to an upstream error");
     }
 
     @ExceptionHandler(TossPaymentCancelException.class)
     public ResponseEntity<Map<String, Object>> handleTossCancelFail(TossPaymentCancelException ex) {
         log.error("Toss cancel failed: {}", ex.getMessage());
-        return errorResponse(HttpStatus.BAD_GATEWAY, ex.getMessage());
+        return errorResponse(HttpStatus.BAD_GATEWAY, "Payment cancellation failed due to an upstream error");
     }
 
     private ResponseEntity<Map<String, Object>> errorResponse(HttpStatus status, String message) {

--- a/src/main/java/org/ticketing/payment/presentation/advice/PaymentControllerAdvice.java
+++ b/src/main/java/org/ticketing/payment/presentation/advice/PaymentControllerAdvice.java
@@ -1,0 +1,85 @@
+package org.ticketing.payment.presentation.advice;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.ticketing.payment.domain.exception.DuplicatePaymentException;
+import org.ticketing.payment.domain.exception.InvalidPaymentStatusTransitionException;
+import org.ticketing.payment.domain.exception.PaymentAlreadyTerminatedException;
+import org.ticketing.payment.domain.exception.PaymentAmountMismatchException;
+import org.ticketing.payment.domain.exception.PaymentNotFoundException;
+import org.ticketing.payment.domain.exception.PaymentReservationMismatchException;
+import org.ticketing.payment.domain.exception.TossPaymentCancelException;
+import org.ticketing.payment.domain.exception.TossPaymentConfirmException;
+
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Slf4j
+@RestControllerAdvice
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class PaymentControllerAdvice {
+
+    @ExceptionHandler(PaymentNotFoundException.class)
+    public ResponseEntity<Map<String, Object>> handlePaymentNotFound(PaymentNotFoundException ex) {
+        return errorResponse(HttpStatus.NOT_FOUND, ex.getMessage());
+    }
+
+    @ExceptionHandler(DuplicatePaymentException.class)
+    public ResponseEntity<Map<String, Object>> handleDuplicatePayment(DuplicatePaymentException ex) {
+        return errorResponse(HttpStatus.CONFLICT, ex.getMessage());
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<Map<String, Object>> handleDataIntegrityViolation(DataIntegrityViolationException ex) {
+        log.warn("DataIntegrityViolation (concurrent duplicate payment): {}", ex.getMostSpecificCause().getMessage());
+        return errorResponse(HttpStatus.CONFLICT, "Active payment already exists for this reservation");
+    }
+
+    @ExceptionHandler(InvalidPaymentStatusTransitionException.class)
+    public ResponseEntity<Map<String, Object>> handleInvalidStatusTransition(InvalidPaymentStatusTransitionException ex) {
+        return errorResponse(HttpStatus.CONFLICT, ex.getMessage());
+    }
+
+    @ExceptionHandler(PaymentAlreadyTerminatedException.class)
+    public ResponseEntity<Map<String, Object>> handleAlreadyTerminated(PaymentAlreadyTerminatedException ex) {
+        return errorResponse(HttpStatus.CONFLICT, ex.getMessage());
+    }
+
+    @ExceptionHandler(PaymentAmountMismatchException.class)
+    public ResponseEntity<Map<String, Object>> handleAmountMismatch(PaymentAmountMismatchException ex) {
+        return errorResponse(HttpStatus.BAD_REQUEST, ex.getMessage());
+    }
+
+    @ExceptionHandler(PaymentReservationMismatchException.class)
+    public ResponseEntity<Map<String, Object>> handleReservationMismatch(PaymentReservationMismatchException ex) {
+        return errorResponse(HttpStatus.BAD_REQUEST, ex.getMessage());
+    }
+
+    @ExceptionHandler(TossPaymentConfirmException.class)
+    public ResponseEntity<Map<String, Object>> handleTossConfirmFail(TossPaymentConfirmException ex) {
+        log.error("Toss confirm failed: {}", ex.getMessage());
+        return errorResponse(HttpStatus.BAD_GATEWAY, ex.getMessage());
+    }
+
+    @ExceptionHandler(TossPaymentCancelException.class)
+    public ResponseEntity<Map<String, Object>> handleTossCancelFail(TossPaymentCancelException ex) {
+        log.error("Toss cancel failed: {}", ex.getMessage());
+        return errorResponse(HttpStatus.BAD_GATEWAY, ex.getMessage());
+    }
+
+    private ResponseEntity<Map<String, Object>> errorResponse(HttpStatus status, String message) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("status", status.value());
+        body.put("error", status.toString());
+        body.put("message", message);
+        body.put("timestamp", Instant.now().toString());
+        return ResponseEntity.status(status).body(body);
+    }
+}

--- a/src/test/java/org/ticketing/payment/application/service/PaymentServiceTest.java
+++ b/src/test/java/org/ticketing/payment/application/service/PaymentServiceTest.java
@@ -1,0 +1,223 @@
+package org.ticketing.payment.application.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.ticketing.payment.application.dto.command.ConfirmPaymentCommand;
+import org.ticketing.payment.application.dto.command.CreatePaymentCommand;
+import org.ticketing.payment.application.dto.result.PaymentResult;
+import org.ticketing.payment.domain.exception.DuplicatePaymentException;
+import org.ticketing.payment.domain.exception.PaymentNotFoundException;
+import org.ticketing.payment.domain.model.Payment;
+import org.ticketing.payment.domain.model.PaymentStatus;
+import org.ticketing.payment.domain.repository.PaymentRepository;
+import org.ticketing.payment.infrastructure.toss.TossPaymentClient;
+import org.ticketing.payment.infrastructure.toss.dto.TossConfirmResponse;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PaymentService")
+class PaymentServiceTest {
+
+    @Mock PaymentRepository paymentRepository;
+    @Mock TossPaymentClient tossPaymentClient;
+    @Mock PaymentStatusService paymentStatusService;
+    @InjectMocks PaymentService paymentService;
+
+    private static final UUID USER_ID = UUID.randomUUID();
+    private static final UUID RESERVATION_ID = UUID.randomUUID();
+    private static final UUID PAYMENT_ID = UUID.randomUUID();
+    private static final long PRICE = 10_000L;
+
+    @Nested
+    @DisplayName("createPayment")
+    class CreatePayment {
+
+        private CreatePaymentCommand command;
+
+        @BeforeEach
+        void setUp() {
+            command = new CreatePaymentCommand(USER_ID, RESERVATION_ID, PRICE);
+        }
+
+        @Test
+        void 정상_생성() {
+            Payment payment = Payment.create(USER_ID, RESERVATION_ID, PRICE);
+            given(paymentRepository.existsActivePayment(RESERVATION_ID)).willReturn(false);
+            given(paymentRepository.save(any(Payment.class))).willReturn(payment);
+
+            PaymentResult result = paymentService.createPayment(command);
+
+            assertThat(result.getUserId()).isEqualTo(USER_ID);
+            assertThat(result.getReservationId()).isEqualTo(RESERVATION_ID);
+            assertThat(result.getTotalPrice()).isEqualTo(PRICE);
+            assertThat(result.getStatus()).isEqualTo(PaymentStatus.INIT);
+        }
+
+        @Test
+        void 결제_정보와_불일치시() {
+
+        }
+
+        @Test
+        void 동일_예약에_진행중인_결제_존재시_DuplicatePaymentException() {
+            given(paymentRepository.existsActivePayment(RESERVATION_ID)).willReturn(true);
+
+            assertThatThrownBy(() -> paymentService.createPayment(command))
+                    .isInstanceOf(DuplicatePaymentException.class);
+
+            verify(paymentRepository, never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("confirmPayment")
+    class ConfirmPayment {
+
+        private ConfirmPaymentCommand command;
+
+        @BeforeEach
+        void setUp() {
+            command = new ConfirmPaymentCommand("toss-key", PAYMENT_ID, PRICE);
+        }
+
+        @Test
+        void 정상_승인() {
+            TossConfirmResponse tossResponse = tossConfirmResponse("toss-confirmed-key");
+            given(tossPaymentClient.confirm("toss-key", PAYMENT_ID.toString(), PRICE))
+                    .willReturn(tossResponse);
+
+            PaymentResult successResult = paymentResult(PaymentStatus.SUCCESS);
+            given(paymentStatusService.succeedPayment(PAYMENT_ID, "toss-confirmed-key"))
+                    .willReturn(successResult);
+
+            PaymentResult result = paymentService.confirmPayment(command);
+
+            assertThat(result.getStatus()).isEqualTo(PaymentStatus.SUCCESS);
+            verify(paymentStatusService).startPayment(PAYMENT_ID, PRICE);
+            verify(tossPaymentClient).confirm("toss-key", PAYMENT_ID.toString(), PRICE);
+            verify(paymentStatusService).succeedPayment(PAYMENT_ID, "toss-confirmed-key");
+        }
+
+        @Test
+        void Toss_실패시_failPayment_호출_후_예외_전파() {
+            given(tossPaymentClient.confirm(any(), any(), any()))
+                    .willThrow(new RuntimeException("Toss 통신 오류"));
+
+            assertThatThrownBy(() -> paymentService.confirmPayment(command))
+                    .isInstanceOf(RuntimeException.class);
+
+            verify(paymentStatusService).failPayment(PAYMENT_ID);
+            verify(paymentStatusService, never()).succeedPayment(any(), any());
+        }
+
+        @Test
+        void Toss_실패시_startPayment는_이미_호출된다() {
+            given(tossPaymentClient.confirm(any(), any(), any()))
+                    .willThrow(new RuntimeException("Toss 통신 오류"));
+
+            assertThatThrownBy(() -> paymentService.confirmPayment(command))
+                    .isInstanceOf(RuntimeException.class);
+
+            // INIT → PAYING 전이는 Toss 호출 전에 완료됨
+            verify(paymentStatusService).startPayment(PAYMENT_ID, PRICE);
+        }
+
+        @Test
+        void startPayment_실패시_Toss_미호출() {
+            willThrow(new RuntimeException("금액 불일치"))
+                    .given(paymentStatusService).startPayment(PAYMENT_ID, PRICE);
+
+            assertThatThrownBy(() -> paymentService.confirmPayment(command))
+                    .isInstanceOf(RuntimeException.class);
+
+            verify(tossPaymentClient, never()).confirm(any(), any(), any());
+            verify(paymentStatusService, never()).failPayment(any());
+            verify(paymentStatusService, never()).succeedPayment(any(), any());
+        }
+    }
+
+    @Nested
+    @DisplayName("getPayment")
+    class GetPayment {
+
+        @Test
+        void 존재하는_결제_조회() {
+            Payment payment = Payment.create(USER_ID, RESERVATION_ID, PRICE);
+            given(paymentRepository.findById(PAYMENT_ID)).willReturn(Optional.of(payment));
+
+            PaymentResult result = paymentService.getPayment(PAYMENT_ID);
+
+            assertThat(result.getStatus()).isEqualTo(PaymentStatus.INIT);
+        }
+
+        @Test
+        void 존재하지_않는_결제_조회시_PaymentNotFoundException() {
+            given(paymentRepository.findById(PAYMENT_ID)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> paymentService.getPayment(PAYMENT_ID))
+                    .isInstanceOf(PaymentNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("refundPayment")
+    class RefundPayment {
+
+        @Test
+        void 정상_환불() {
+            Payment payment = Payment.create(USER_ID, RESERVATION_ID, PRICE);
+            payment.start();
+            payment.succeed("toss-key");
+            given(paymentStatusService.startRefund(RESERVATION_ID)).willReturn(payment);
+
+            PaymentResult refundedResult = paymentResult(PaymentStatus.REFUNDED);
+            given(paymentStatusService.refundPayment(payment.getId())).willReturn(refundedResult);
+
+            PaymentResult result = paymentService.refundPayment(RESERVATION_ID);
+
+            assertThat(result.getStatus()).isEqualTo(PaymentStatus.REFUNDED);
+            verify(tossPaymentClient).cancel("toss-key", "고객 요청 취소");
+        }
+
+        @Test
+        void Toss_취소_실패시_refundPayment_미호출() {
+            Payment payment = Payment.create(USER_ID, RESERVATION_ID, PRICE);
+            payment.start();
+            payment.succeed("toss-key");
+            given(paymentStatusService.startRefund(RESERVATION_ID)).willReturn(payment);
+            given(tossPaymentClient.cancel(any(), any())).willThrow(new RuntimeException("Toss 취소 실패"));
+
+            assertThatThrownBy(() -> paymentService.refundPayment(RESERVATION_ID))
+                    .isInstanceOf(RuntimeException.class);
+
+            verify(paymentStatusService, never()).refundPayment(any());
+        }
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private TossConfirmResponse tossConfirmResponse(String paymentKey) {
+        TossConfirmResponse response = mock(TossConfirmResponse.class);
+        given(response.getPaymentKey()).willReturn(paymentKey);
+        return response;
+    }
+
+    private PaymentResult paymentResult(PaymentStatus status) {
+        return new PaymentResult(PAYMENT_ID, USER_ID, RESERVATION_ID, PRICE, status);
+    }
+}

--- a/src/test/java/org/ticketing/payment/domain/model/PaymentStatusTest.java
+++ b/src/test/java/org/ticketing/payment/domain/model/PaymentStatusTest.java
@@ -1,0 +1,176 @@
+package org.ticketing.payment.domain.model;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("PaymentStatus 상태 머신")
+class PaymentStatusTest {
+
+    @Nested
+    @DisplayName("허용된 전이")
+    class AllowedTransitions {
+
+        @Test
+        void INIT에서_PAYING으로_전이_가능() {
+            assertThat(PaymentStatus.INIT.canTransitionTo(PaymentStatus.PAYING)).isTrue();
+        }
+
+        @Test
+        void INIT에서_EXPIRED로_전이_가능() {
+            assertThat(PaymentStatus.INIT.canTransitionTo(PaymentStatus.EXPIRED)).isTrue();
+        }
+
+        @Test
+        void PAYING에서_SUCCESS로_전이_가능() {
+            assertThat(PaymentStatus.PAYING.canTransitionTo(PaymentStatus.SUCCESS)).isTrue();
+        }
+
+        @Test
+        void PAYING에서_FAIL로_전이_가능() {
+            assertThat(PaymentStatus.PAYING.canTransitionTo(PaymentStatus.FAIL)).isTrue();
+        }
+
+        @Test
+        void PAYING에서_REFUNDING으로_전이_가능() {
+            assertThat(PaymentStatus.PAYING.canTransitionTo(PaymentStatus.REFUNDING)).isTrue();
+        }
+
+        @Test
+        void PAYING에서_EXPIRED로_전이_가능() {
+            assertThat(PaymentStatus.PAYING.canTransitionTo(PaymentStatus.EXPIRED)).isTrue();
+        }
+
+        @Test
+        void SUCCESS에서_REFUNDING으로_전이_가능() {
+            assertThat(PaymentStatus.SUCCESS.canTransitionTo(PaymentStatus.REFUNDING)).isTrue();
+        }
+
+        @Test
+        void SUCCESS에서_FAIL로_전이_가능() {
+            assertThat(PaymentStatus.SUCCESS.canTransitionTo(PaymentStatus.FAIL)).isTrue();
+        }
+
+        @Test
+        void SUCCESS에서_EXPIRED로_전이_가능() {
+            assertThat(PaymentStatus.SUCCESS.canTransitionTo(PaymentStatus.EXPIRED)).isTrue();
+        }
+
+        @Test
+        void REFUNDING에서_REFUNDED로_전이_가능() {
+            assertThat(PaymentStatus.REFUNDING.canTransitionTo(PaymentStatus.REFUNDED)).isTrue();
+        }
+
+        @Test
+        void REFUNDING에서_SUCCESS로_전이_가능() {
+            assertThat(PaymentStatus.REFUNDING.canTransitionTo(PaymentStatus.SUCCESS)).isTrue();
+        }
+
+        @Test
+        void REFUNDING에서_FAIL로_전이_가능() {
+            assertThat(PaymentStatus.REFUNDING.canTransitionTo(PaymentStatus.FAIL)).isTrue();
+        }
+
+        @Test
+        void REFUNDING에서_EXPIRED로_전이_가능() {
+            assertThat(PaymentStatus.REFUNDING.canTransitionTo(PaymentStatus.EXPIRED)).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("차단된 전이")
+    class BlockedTransitions {
+
+        @Test
+        void INIT에서_SUCCESS로_직행_불가() {
+            assertThat(PaymentStatus.INIT.canTransitionTo(PaymentStatus.SUCCESS)).isFalse();
+        }
+
+        @Test
+        void INIT에서_FAIL로_직행_불가() {
+            assertThat(PaymentStatus.INIT.canTransitionTo(PaymentStatus.FAIL)).isFalse();
+        }
+
+        @Test
+        void INIT에서_REFUNDING으로_직행_불가() {
+            assertThat(PaymentStatus.INIT.canTransitionTo(PaymentStatus.REFUNDING)).isFalse();
+        }
+
+        @Test
+        void PAYING에서_INIT으로_되돌아가기_불가() {
+            assertThat(PaymentStatus.PAYING.canTransitionTo(PaymentStatus.INIT)).isFalse();
+        }
+
+        @Test
+        void SUCCESS에서_INIT으로_되돌아가기_불가() {
+            assertThat(PaymentStatus.SUCCESS.canTransitionTo(PaymentStatus.INIT)).isFalse();
+        }
+
+        @Test
+        void SUCCESS에서_PAYING으로_되돌아가기_불가() {
+            assertThat(PaymentStatus.SUCCESS.canTransitionTo(PaymentStatus.PAYING)).isFalse();
+        }
+
+        @ParameterizedTest(name = "FAIL에서 {0}으로 전이 불가 — terminal 상태")
+        @EnumSource(PaymentStatus.class)
+        void FAIL은_모든_상태로_전이_불가(PaymentStatus next) {
+            assertThat(PaymentStatus.FAIL.canTransitionTo(next)).isFalse();
+        }
+
+        @ParameterizedTest(name = "REFUNDED에서 {0}으로 전이 불가 — terminal 상태")
+        @EnumSource(PaymentStatus.class)
+        void REFUNDED는_모든_상태로_전이_불가(PaymentStatus next) {
+            assertThat(PaymentStatus.REFUNDED.canTransitionTo(next)).isFalse();
+        }
+
+        @ParameterizedTest(name = "EXPIRED에서 {0}으로 전이 불가 — terminal 상태")
+        @EnumSource(PaymentStatus.class)
+        void EXPIRED는_모든_상태로_전이_불가(PaymentStatus next) {
+            assertThat(PaymentStatus.EXPIRED.canTransitionTo(next)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("isTerminal")
+    class Terminal {
+
+        @Test
+        void FAIL은_terminal() {
+            assertThat(PaymentStatus.FAIL.isTerminal()).isTrue();
+        }
+
+        @Test
+        void REFUNDED는_terminal() {
+            assertThat(PaymentStatus.REFUNDED.isTerminal()).isTrue();
+        }
+
+        @Test
+        void EXPIRED는_terminal() {
+            assertThat(PaymentStatus.EXPIRED.isTerminal()).isTrue();
+        }
+
+        @Test
+        void INIT은_non_terminal() {
+            assertThat(PaymentStatus.INIT.isTerminal()).isFalse();
+        }
+
+        @Test
+        void PAYING은_non_terminal() {
+            assertThat(PaymentStatus.PAYING.isTerminal()).isFalse();
+        }
+
+        @Test
+        void SUCCESS는_non_terminal() {
+            assertThat(PaymentStatus.SUCCESS.isTerminal()).isFalse();
+        }
+
+        @Test
+        void REFUNDING은_non_terminal() {
+            assertThat(PaymentStatus.REFUNDING.isTerminal()).isFalse();
+        }
+    }
+}

--- a/src/test/java/org/ticketing/payment/domain/model/PaymentStatusTest.java
+++ b/src/test/java/org/ticketing/payment/domain/model/PaymentStatusTest.java
@@ -36,11 +36,6 @@ class PaymentStatusTest {
         }
 
         @Test
-        void PAYING에서_REFUNDING으로_전이_가능() {
-            assertThat(PaymentStatus.PAYING.canTransitionTo(PaymentStatus.REFUNDING)).isTrue();
-        }
-
-        @Test
         void PAYING에서_EXPIRED로_전이_가능() {
             assertThat(PaymentStatus.PAYING.canTransitionTo(PaymentStatus.EXPIRED)).isTrue();
         }

--- a/src/test/java/org/ticketing/payment/domain/model/PaymentTest.java
+++ b/src/test/java/org/ticketing/payment/domain/model/PaymentTest.java
@@ -1,0 +1,256 @@
+package org.ticketing.payment.domain.model;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.ticketing.payment.domain.exception.InvalidPaymentStatusTransitionException;
+import org.ticketing.payment.domain.exception.PaymentAlreadyTerminatedException;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("Payment 도메인")
+class PaymentTest {
+
+    private static final UUID USER_ID = UUID.randomUUID();
+    private static final UUID RESERVATION_ID = UUID.randomUUID();
+    private static final long PRICE = 10_000L;
+
+    private Payment payment;
+
+    @BeforeEach
+    void setUp() {
+        payment = Payment.create(USER_ID, RESERVATION_ID, PRICE);
+    }
+
+    @Nested
+    @DisplayName("create")
+    class Create {
+
+        @Test
+        void 초기_상태는_INIT() {
+            assertThat(payment.getStatus()).isEqualTo(PaymentStatus.INIT);
+        }
+
+        @Test
+        void userId_reservationId_totalPrice_저장() {
+            assertThat(payment.getUserId()).isEqualTo(USER_ID);
+            assertThat(payment.getReservationId()).isEqualTo(RESERVATION_ID);
+            assertThat(payment.getTotalPrice()).isEqualTo(PRICE);
+        }
+
+        @Test
+        void paymentKey는_null로_초기화() {
+            assertThat(payment.getPaymentKey()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("start — INIT → PAYING")
+    class Start {
+
+        @Test
+        void 상태가_PAYING으로_변경된다() {
+            payment.start();
+            assertThat(payment.getStatus()).isEqualTo(PaymentStatus.PAYING);
+        }
+
+        @Test
+        void PAYING_상태에서_재호출시_InvalidPaymentStatusTransitionException() {
+            payment.start();
+            assertThatThrownBy(payment::start)
+                    .isInstanceOf(InvalidPaymentStatusTransitionException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("succeed — PAYING → SUCCESS")
+    class Succeed {
+
+        @Test
+        void 상태가_SUCCESS로_변경되고_paymentKey_저장() {
+            payment.start();
+            payment.succeed("toss-key-abc");
+
+            assertThat(payment.getStatus()).isEqualTo(PaymentStatus.SUCCESS);
+            assertThat(payment.getPaymentKey()).isEqualTo("toss-key-abc");
+        }
+
+        @Test
+        void INIT_상태에서_직접_succeed_호출시_InvalidPaymentStatusTransitionException() {
+            assertThatThrownBy(() -> payment.succeed("key"))
+                    .isInstanceOf(InvalidPaymentStatusTransitionException.class);
+        }
+
+        @Test
+        void 이미_SUCCESS인_상태에서_succeed_호출시_PaymentAlreadyTerminatedException은_아니다() {
+            payment.start();
+            payment.succeed("key");
+
+            assertThatThrownBy(() -> payment.succeed("key2"))
+                    .isInstanceOf(InvalidPaymentStatusTransitionException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("fail — PAYING → FAIL")
+    class Fail {
+
+        @Test
+        void 상태가_FAIL로_변경된다() {
+            payment.start();
+            payment.fail();
+            assertThat(payment.getStatus()).isEqualTo(PaymentStatus.FAIL);
+        }
+
+        @Test
+        void INIT에서_fail_호출시_InvalidPaymentStatusTransitionException() {
+            assertThatThrownBy(payment::fail)
+                    .isInstanceOf(InvalidPaymentStatusTransitionException.class);
+        }
+
+        @Test
+        void FAIL_이후_모든_전이_시도시_PaymentAlreadyTerminatedException() {
+            payment.start();
+            payment.fail();
+
+            assertThatThrownBy(payment::start)
+                    .isInstanceOf(PaymentAlreadyTerminatedException.class);
+            assertThatThrownBy(() -> payment.succeed("key"))
+                    .isInstanceOf(PaymentAlreadyTerminatedException.class);
+            assertThatThrownBy(payment::fail)
+                    .isInstanceOf(PaymentAlreadyTerminatedException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("startRefund — SUCCESS → REFUNDING")
+    class StartRefund {
+
+        @Test
+        void 상태가_REFUNDING으로_변경된다() {
+            payment.start();
+            payment.succeed("key");
+            payment.startRefund();
+            assertThat(payment.getStatus()).isEqualTo(PaymentStatus.REFUNDING);
+        }
+
+        @Test
+        void INIT에서_startRefund_호출시_InvalidPaymentStatusTransitionException() {
+            assertThatThrownBy(payment::startRefund)
+                    .isInstanceOf(InvalidPaymentStatusTransitionException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("refund — REFUNDING → REFUNDED")
+    class Refund {
+
+        @Test
+        void 상태가_REFUNDED로_변경된다() {
+            payment.start();
+            payment.succeed("key");
+            payment.startRefund();
+            payment.refund();
+            assertThat(payment.getStatus()).isEqualTo(PaymentStatus.REFUNDED);
+        }
+
+        @Test
+        void REFUNDED_이후_모든_전이_시도시_PaymentAlreadyTerminatedException() {
+            payment.start();
+            payment.succeed("key");
+            payment.startRefund();
+            payment.refund();
+
+            assertThatThrownBy(payment::refund)
+                    .isInstanceOf(PaymentAlreadyTerminatedException.class);
+            assertThatThrownBy(payment::startRefund)
+                    .isInstanceOf(PaymentAlreadyTerminatedException.class);
+        }
+
+        @Test
+        void INIT에서_refund_직접_호출시_InvalidPaymentStatusTransitionException() {
+            assertThatThrownBy(payment::refund)
+                    .isInstanceOf(InvalidPaymentStatusTransitionException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("expire")
+    class Expire {
+
+        @Test
+        void INIT에서_EXPIRED로_전이된다() {
+            payment.expire();
+            assertThat(payment.getStatus()).isEqualTo(PaymentStatus.EXPIRED);
+        }
+
+        @Test
+        void PAYING에서_EXPIRED로_전이된다() {
+            payment.start();
+            payment.expire();
+            assertThat(payment.getStatus()).isEqualTo(PaymentStatus.EXPIRED);
+        }
+
+        @Test
+        void EXPIRED_이후_모든_전이_시도시_PaymentAlreadyTerminatedException() {
+            payment.expire();
+
+            assertThatThrownBy(payment::start)
+                    .isInstanceOf(PaymentAlreadyTerminatedException.class);
+            assertThatThrownBy(() -> payment.succeed("key"))
+                    .isInstanceOf(PaymentAlreadyTerminatedException.class);
+            assertThatThrownBy(payment::expire)
+                    .isInstanceOf(PaymentAlreadyTerminatedException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("정상 결제 완료 시나리오 — INIT → PAYING → SUCCESS")
+    class HappyPath {
+
+        @Test
+        void 전체_결제_성공_흐름() {
+            assertThat(payment.getStatus()).isEqualTo(PaymentStatus.INIT);
+
+            payment.start();
+            assertThat(payment.getStatus()).isEqualTo(PaymentStatus.PAYING);
+
+            payment.succeed("toss-confirmed-key");
+            assertThat(payment.getStatus()).isEqualTo(PaymentStatus.SUCCESS);
+            assertThat(payment.getPaymentKey()).isEqualTo("toss-confirmed-key");
+        }
+    }
+
+    @Nested
+    @DisplayName("환불 시나리오 — SUCCESS → REFUNDING → REFUNDED")
+    class RefundScenario {
+
+        @Test
+        void 전체_환불_흐름() {
+            payment.start();
+            payment.succeed("key");
+            payment.startRefund();
+            payment.refund();
+
+            assertThat(payment.getStatus()).isEqualTo(PaymentStatus.REFUNDED);
+        }
+    }
+
+    @Nested
+    @DisplayName("결제 실패 시나리오 — INIT → PAYING → FAIL")
+    class FailScenario {
+
+        @Test
+        void PG_실패로_인한_결제_실패_흐름() {
+            payment.start();
+            payment.fail();
+
+            assertThat(payment.getStatus()).isEqualTo(PaymentStatus.FAIL);
+            assertThat(payment.getPaymentKey()).isNull();
+        }
+    }
+}


### PR DESCRIPTION
### 📎 관련 이슈
- close #16 #24 

### 📌 작업 내용
- PaymentStatus 변경에 따른 PaymentLog 기록 추가
- Feign Todo 작성
- PaymentStatus에서 Paying->Refunding 전이 불가로 삭제
- TOSS_BASE_URL 하드코딩 제거
- payment, paymentStatus 도메인 테스트 
- paymentService 단위 테스트

### ✨ 변경 사항
- 주요 변경 내용 정리

### 📝 리뷰 포인트 (선택)
- 집중해서 봐줬으면 하는 부분

### 🧠 기타 참고 사항
(참고 문서, 스크린샷 등)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted payment state transitions so an in-progress payment (PAYING) cannot move directly to refunding.

* **New Features**
  * Added persistent audit logs for payment status changes to improve traceability.
  * Made external payment provider base URL configurable with a sensible default.
  * Centralized API error handling for payment-related errors with consistent HTTP responses.

* **Tests**
  * Added comprehensive tests covering creation, confirmation, refunds, and state transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->