### PR TITLE
Feat: Reservation Feign api 연결, 권한 별 인증, Test용 Toss Mock 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ out/
 
 ### QueryDSL ###
 src/main/generated/
+.env

--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,7 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     implementation 'org.springframework.kafka:spring-kafka'
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/ticketing/payment/PaymentApplication.java
+++ b/src/main/java/org/ticketing/payment/PaymentApplication.java
@@ -2,8 +2,10 @@ package org.ticketing.payment;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
+@EnableFeignClients
 public class PaymentApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/org/ticketing/payment/application/dto/command/ConfirmPaymentCommand.java
+++ b/src/main/java/org/ticketing/payment/application/dto/command/ConfirmPaymentCommand.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class ConfirmPaymentCommand {
 
+    private UUID userId;
     private String paymentKey;
     private UUID paymentId;
     private Long totalPrice;

--- a/src/main/java/org/ticketing/payment/application/dto/command/CreatePaymentCommand.java
+++ b/src/main/java/org/ticketing/payment/application/dto/command/CreatePaymentCommand.java
@@ -10,5 +10,4 @@ public class CreatePaymentCommand {
 
     private UUID userId;
     private UUID reservationId;
-    private Long totalPrice;
 }

--- a/src/main/java/org/ticketing/payment/application/service/PaymentRecoveryService.java
+++ b/src/main/java/org/ticketing/payment/application/service/PaymentRecoveryService.java
@@ -11,8 +11,8 @@ import org.springframework.transaction.annotation.Transactional;
 import org.ticketing.payment.domain.model.Payment;
 import org.ticketing.payment.domain.model.PaymentStatus;
 import org.ticketing.payment.domain.repository.PaymentRepository;
-import org.ticketing.payment.infrastructure.toss.TossPaymentClient;
-import org.ticketing.payment.infrastructure.toss.dto.TossPaymentStatusResponse;
+import org.ticketing.payment.domain.provider.TossPaymentProvider;
+import org.ticketing.payment.domain.provider.TossPaymentProvider.StatusResult;
 
 @Slf4j
 @Service
@@ -23,7 +23,7 @@ public class PaymentRecoveryService {
 
     private final PaymentRepository paymentRepository;
     private final PaymentStatusService paymentStatusService;
-    private final TossPaymentClient tossPaymentClient;
+    private final TossPaymentProvider tossPaymentProvider;
 
     @Transactional
     public List<Payment> findStuckPaying(LocalDateTime before) {
@@ -37,19 +37,19 @@ public class PaymentRecoveryService {
 
     public void recoverPaying(Payment payment) {
         UUID paymentId = payment.getId();
-        TossPaymentStatusResponse toss;
+        StatusResult toss;
         try {
-            toss = tossPaymentClient.getByOrderId(paymentId.toString());
+            toss = tossPaymentProvider.getByOrderId(paymentId.toString());
         } catch (Exception e) {
             log.warn("[복구 실패] PAYING 상태 Toss 조회 실패. paymentId={}", paymentId, e);
             return;
         }
 
-        switch (toss.getStatus()) {
+        switch (toss.status()) {
             case "DONE" -> {
                 // toss O, payment status X
                 log.info("[복구] PAYING → SUCCESS. paymentId={}", paymentId);
-                paymentStatusService.succeedPayment(paymentId, toss.getPaymentKey());
+                paymentStatusService.succeedPayment(paymentId, toss.paymentKey());
             }
             case "ABORTED", "EXPIRED" -> {
                 // toss X, payment status X
@@ -62,15 +62,15 @@ public class PaymentRecoveryService {
 
     public void recoverRefunding(Payment payment) {
         UUID paymentId = payment.getId();
-        TossPaymentStatusResponse toss;
+        StatusResult toss;
         try {
-            toss = tossPaymentClient.getByPaymentKey(payment.getPaymentKey());
+            toss = tossPaymentProvider.getByPaymentKey(payment.getPaymentKey());
         } catch (Exception e) {
             log.warn("[복구 실패] REFUNDING 상태 Toss 조회 실패. paymentId={}", paymentId, e);
             return;
         }
 
-        switch (toss.getStatus()) {
+        switch (toss.status()) {
             case "CANCELED" -> {
                 // toss O, payment status X
                 log.info("[복구] REFUNDING → REFUNDED. paymentId={}", paymentId);
@@ -86,7 +86,7 @@ public class PaymentRecoveryService {
                 }
                 log.info("[복구] REFUNDING - Toss 미취소 상태, 취소 재시도. paymentId={}", paymentId);
                 try {
-                    tossPaymentClient.cancel(payment.getPaymentKey(), "고객 요청 취소");
+                    tossPaymentProvider.cancel(payment.getPaymentKey(), "고객 요청 취소");
                     paymentStatusService.refundPayment(paymentId);
                 } catch (Exception e) {
                     log.error("[복구 실패] 취소 재시도 실패. paymentId={}", paymentId, e);

--- a/src/main/java/org/ticketing/payment/application/service/PaymentRecoveryService.java
+++ b/src/main/java/org/ticketing/payment/application/service/PaymentRecoveryService.java
@@ -53,10 +53,10 @@ public class PaymentRecoveryService {
             }
             case "ABORTED", "EXPIRED" -> {
                 // toss X, payment status X
-                log.info("[복구] PAYING → FAIL. paymentId={}, tossStatus={}", paymentId, toss.getStatus());
+                log.info("[복구] PAYING → FAIL. paymentId={}, tossStatus={}", paymentId, toss.status());
                 paymentStatusService.failPayment(paymentId);
             }
-            default -> log.debug("[복구 스킵] PAYING 아직 진행 중. paymentId={}, tossStatus={}", paymentId, toss.getStatus());
+            default -> log.debug("[복구 스킵] PAYING 아직 진행 중. paymentId={}, tossStatus={}", paymentId, toss.status());
         }
     }
 
@@ -92,7 +92,7 @@ public class PaymentRecoveryService {
                     log.error("[복구 실패] 취소 재시도 실패. paymentId={}", paymentId, e);
                 }
             }
-            default -> log.warn("[복구 스킵] REFUNDING 알 수 없는 상태. paymentId={}, tossStatus={}", paymentId, toss.getStatus());
+            default -> log.warn("[복구 스킵] REFUNDING 알 수 없는 상태. paymentId={}, tossStatus={}", paymentId, toss.status());
         }
     }
 }

--- a/src/main/java/org/ticketing/payment/application/service/PaymentService.java
+++ b/src/main/java/org/ticketing/payment/application/service/PaymentService.java
@@ -17,8 +17,8 @@ import org.ticketing.payment.domain.model.Payment;
 import org.ticketing.payment.domain.repository.PaymentRepository;
 import org.ticketing.payment.domain.provider.ReservationProvider;
 import org.ticketing.payment.domain.provider.ReservationProvider.ReservationSnapshot;
-import org.ticketing.payment.infrastructure.toss.TossPaymentClient;
-import org.ticketing.payment.infrastructure.toss.dto.TossConfirmResponse;
+import org.ticketing.payment.domain.provider.TossPaymentProvider;
+import org.ticketing.payment.domain.provider.TossPaymentProvider.ConfirmResult;
 
 import java.util.UUID;
 
@@ -28,7 +28,7 @@ import java.util.UUID;
 public class PaymentService {
 
     private final PaymentRepository paymentRepository;
-    private final TossPaymentClient tossPaymentClient;
+    private final TossPaymentProvider tossPaymentProvider;
     private final PaymentStatusService paymentStatusService;
     private final ReservationProvider reservationProvider;
 
@@ -83,7 +83,7 @@ public class PaymentService {
 
     public PaymentResult refundPayment(UUID reservationId) {
         Payment payment = paymentStatusService.startRefund(reservationId);
-        tossPaymentClient.cancel(payment.getPaymentKey(), "고객 요청 취소");
+        tossPaymentProvider.cancel(payment.getPaymentKey(), "고객 요청 취소");
         return paymentStatusService.refundPayment(payment.getId());
     }
 
@@ -98,9 +98,9 @@ public class PaymentService {
     public PaymentResult confirmPayment(ConfirmPaymentCommand command) {
         paymentStatusService.startPayment(command.getPaymentId(), command.getTotalPrice());
 
-        TossConfirmResponse tossResponse;
+        ConfirmResult tossResponse;
         try {
-            tossResponse = tossPaymentClient.confirm(
+            tossResponse = tossPaymentProvider.confirm(
                     command.getPaymentKey(),
                     command.getPaymentId().toString(),
                     command.getTotalPrice()
@@ -110,6 +110,6 @@ public class PaymentService {
             throw new RuntimeException(e);
         }
 
-        return paymentStatusService.succeedPayment(command.getPaymentId(), tossResponse.getPaymentKey());
+        return paymentStatusService.succeedPayment(command.getPaymentId(), tossResponse.paymentKey());
     }
 }

--- a/src/main/java/org/ticketing/payment/application/service/PaymentService.java
+++ b/src/main/java/org/ticketing/payment/application/service/PaymentService.java
@@ -9,8 +9,8 @@ import org.ticketing.payment.application.dto.command.ConfirmPaymentCommand;
 import org.ticketing.payment.application.dto.command.CreatePaymentCommand;
 import org.ticketing.payment.application.dto.result.PaymentResult;
 import lombok.extern.slf4j.Slf4j;
+import org.ticketing.common.exception.ForbiddenException;
 import org.ticketing.payment.domain.exception.DuplicatePaymentException;
-import org.ticketing.payment.domain.exception.PaymentAmountMismatchException;
 import org.ticketing.payment.domain.exception.PaymentNotFoundException;
 import org.ticketing.payment.infrastructure.kafka.event.ReservationCanceledEvent.CancelReason;
 import org.ticketing.payment.domain.model.Payment;
@@ -60,6 +60,13 @@ public class PaymentService {
     }
 
     @Transactional(readOnly = true)
+    public PaymentResult getMyPayment(UUID userId, UUID paymentId) {
+        Payment payment = paymentRepository.findByIdAndUserId(paymentId, userId)
+                .orElseThrow(() -> new PaymentNotFoundException(paymentId));
+        return PaymentResult.from(payment);
+    }
+
+    @Transactional(readOnly = true)
     public Page<PaymentResult> getPayments(Pageable pageable) {
         return paymentRepository.findAll(pageable).map(PaymentResult::from);
     }
@@ -70,8 +77,20 @@ public class PaymentService {
     }
 
     @Transactional(readOnly = true)
+    public Page<PaymentResult> getMyPaymentsByReservationId(UUID userId, UUID reservationId, Pageable pageable) {
+        return paymentRepository.findByReservationIdAndUserId(reservationId, userId, pageable).map(PaymentResult::from);
+    }
+
+    @Transactional(readOnly = true)
     public PaymentResult getSuccessPaymentByReservationId(UUID reservationId) {
         Payment payment = paymentRepository.findSuccessPaymentByReservationId(reservationId)
+                .orElseThrow(() -> new PaymentNotFoundException(reservationId));
+        return PaymentResult.from(payment);
+    }
+
+    @Transactional(readOnly = true)
+    public PaymentResult getMySuccessPaymentByReservationId(UUID userId, UUID reservationId) {
+        Payment payment = paymentRepository.findSuccessPaymentByReservationIdAndUserId(reservationId, userId)
                 .orElseThrow(() -> new PaymentNotFoundException(reservationId));
         return PaymentResult.from(payment);
     }
@@ -96,6 +115,12 @@ public class PaymentService {
     }
 
     public PaymentResult confirmPayment(ConfirmPaymentCommand command) {
+        Payment payment = paymentRepository.findById(command.getPaymentId())
+                .orElseThrow(() -> new PaymentNotFoundException(command.getPaymentId()));
+        if (!payment.getUserId().equals(command.getUserId())) {
+            throw new ForbiddenException("본인의 결제만 승인할 수 있습니다.");
+        }
+
         paymentStatusService.startPayment(command.getPaymentId(), command.getTotalPrice());
 
         ConfirmResult tossResponse;

--- a/src/main/java/org/ticketing/payment/application/service/PaymentService.java
+++ b/src/main/java/org/ticketing/payment/application/service/PaymentService.java
@@ -10,10 +10,13 @@ import org.ticketing.payment.application.dto.command.CreatePaymentCommand;
 import org.ticketing.payment.application.dto.result.PaymentResult;
 import lombok.extern.slf4j.Slf4j;
 import org.ticketing.payment.domain.exception.DuplicatePaymentException;
+import org.ticketing.payment.domain.exception.PaymentAmountMismatchException;
 import org.ticketing.payment.domain.exception.PaymentNotFoundException;
 import org.ticketing.payment.infrastructure.kafka.event.ReservationCanceledEvent.CancelReason;
 import org.ticketing.payment.domain.model.Payment;
 import org.ticketing.payment.domain.repository.PaymentRepository;
+import org.ticketing.payment.infrastructure.feign.ReservationFeignClient;
+import org.ticketing.payment.infrastructure.feign.dto.InternalReservationResponse;
 import org.ticketing.payment.infrastructure.toss.TossPaymentClient;
 import org.ticketing.payment.infrastructure.toss.dto.TossConfirmResponse;
 
@@ -27,11 +30,15 @@ public class PaymentService {
     private final PaymentRepository paymentRepository;
     private final TossPaymentClient tossPaymentClient;
     private final PaymentStatusService paymentStatusService;
+    private final ReservationFeignClient reservationFeignClient;
 
     @Transactional
     public PaymentResult createPayment(CreatePaymentCommand command) {
 
-        // Todo: [Feign] Reservation reservationId에 대한 reservation 정보 대조 (totalPrice, userId)
+        InternalReservationResponse reservation = reservationFeignClient.getReservation(command.getReservationId());
+        if (!reservation.getUserId().equals(command.getUserId())) {
+            throw new IllegalArgumentException("예약의 userId 불일치: 예약 userId " + reservation.getUserId() + ", 요청 userId " + command.getUserId());
+        }
         // Todo: [Feign] Reservation 해당 예약 상태가 PENDING인지 & 좌석 상태가 HOLD인지 확인
 
         if (paymentRepository.existsActivePayment(command.getReservationId())) {
@@ -40,7 +47,7 @@ public class PaymentService {
         Payment payment = Payment.create(
                 command.getUserId(),
                 command.getReservationId(),
-                command.getTotalPrice()
+                reservation.getTotalPrice()
         );
         return PaymentResult.from(paymentRepository.save(payment));
     }

--- a/src/main/java/org/ticketing/payment/application/service/PaymentService.java
+++ b/src/main/java/org/ticketing/payment/application/service/PaymentService.java
@@ -15,8 +15,8 @@ import org.ticketing.payment.domain.exception.PaymentNotFoundException;
 import org.ticketing.payment.infrastructure.kafka.event.ReservationCanceledEvent.CancelReason;
 import org.ticketing.payment.domain.model.Payment;
 import org.ticketing.payment.domain.repository.PaymentRepository;
-import org.ticketing.payment.infrastructure.feign.ReservationFeignClient;
-import org.ticketing.payment.infrastructure.feign.dto.InternalReservationResponse;
+import org.ticketing.payment.domain.provider.ReservationProvider;
+import org.ticketing.payment.domain.provider.ReservationProvider.ReservationSnapshot;
 import org.ticketing.payment.infrastructure.toss.TossPaymentClient;
 import org.ticketing.payment.infrastructure.toss.dto.TossConfirmResponse;
 
@@ -30,14 +30,14 @@ public class PaymentService {
     private final PaymentRepository paymentRepository;
     private final TossPaymentClient tossPaymentClient;
     private final PaymentStatusService paymentStatusService;
-    private final ReservationFeignClient reservationFeignClient;
+    private final ReservationProvider reservationProvider;
 
     @Transactional
     public PaymentResult createPayment(CreatePaymentCommand command) {
 
-        InternalReservationResponse reservation = reservationFeignClient.getReservation(command.getReservationId());
-        if (!reservation.getUserId().equals(command.getUserId())) {
-            throw new IllegalArgumentException("예약의 userId 불일치: 예약 userId " + reservation.getUserId() + ", 요청 userId " + command.getUserId());
+        ReservationSnapshot reservation = reservationProvider.getReservation(command.getReservationId());
+        if (!reservation.userId().equals(command.getUserId())) {
+            throw new IllegalArgumentException("예약의 userId 불일치: 예약 userId " + reservation.userId() + ", 요청 userId " + command.getUserId());
         }
         // Todo: [Feign] Reservation 해당 예약 상태가 PENDING인지 & 좌석 상태가 HOLD인지 확인
 
@@ -47,7 +47,7 @@ public class PaymentService {
         Payment payment = Payment.create(
                 command.getUserId(),
                 command.getReservationId(),
-                reservation.getTotalPrice()
+                reservation.totalPrice()
         );
         return PaymentResult.from(paymentRepository.save(payment));
     }

--- a/src/main/java/org/ticketing/payment/domain/exception/ReservationNotFoundException.java
+++ b/src/main/java/org/ticketing/payment/domain/exception/ReservationNotFoundException.java
@@ -1,0 +1,10 @@
+package org.ticketing.payment.domain.exception;
+
+import java.util.UUID;
+
+public class ReservationNotFoundException extends RuntimeException {
+
+    public ReservationNotFoundException(UUID reservationId) {
+        super("Reservation not found: " + reservationId);
+    }
+}

--- a/src/main/java/org/ticketing/payment/domain/provider/ReservationProvider.java
+++ b/src/main/java/org/ticketing/payment/domain/provider/ReservationProvider.java
@@ -1,0 +1,10 @@
+package org.ticketing.payment.domain.provider;
+
+import java.util.UUID;
+
+public interface ReservationProvider {
+
+    ReservationSnapshot getReservation(UUID reservationId);
+
+    record ReservationSnapshot(UUID reservationId, UUID userId, Long totalPrice) {}
+}

--- a/src/main/java/org/ticketing/payment/domain/provider/TossPaymentProvider.java
+++ b/src/main/java/org/ticketing/payment/domain/provider/TossPaymentProvider.java
@@ -1,0 +1,16 @@
+package org.ticketing.payment.domain.provider;
+
+public interface TossPaymentProvider {
+
+    ConfirmResult confirm(String paymentKey, String orderId, Long amount);
+
+    void cancel(String paymentKey, String cancelReason);
+
+    StatusResult getByOrderId(String orderId);
+
+    StatusResult getByPaymentKey(String paymentKey);
+
+    record ConfirmResult(String paymentKey, String orderId, String status, Long totalAmount) {}
+
+    record StatusResult(String paymentKey, String orderId, String status, Long totalAmount) {}
+}

--- a/src/main/java/org/ticketing/payment/domain/repository/PaymentRepository.java
+++ b/src/main/java/org/ticketing/payment/domain/repository/PaymentRepository.java
@@ -12,10 +12,13 @@ import org.ticketing.payment.domain.model.PaymentStatus;
 public interface PaymentRepository {
     Payment save(Payment payment);
     Optional<Payment> findById(UUID id);
+    Optional<Payment> findByIdAndUserId(UUID id, UUID userId);
     Page<Payment> findAll(Pageable pageable);
     boolean existsActivePayment(UUID reservationId);
     Page<Payment> findByReservationId(UUID reservationId, Pageable pageable);
+    Page<Payment> findByReservationIdAndUserId(UUID reservationId, UUID userId, Pageable pageable);
     Optional<Payment> findSuccessPaymentByReservationId(UUID reservationId);
+    Optional<Payment> findSuccessPaymentByReservationIdAndUserId(UUID reservationId, UUID userId);
     Page<Payment> findByUserId(UUID userId, Pageable pageable);
     List<Payment> findStuckPayments(PaymentStatus status, LocalDateTime before);
 }

--- a/src/main/java/org/ticketing/payment/infrastructure/config/PaymentSecurityConfig.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/config/PaymentSecurityConfig.java
@@ -1,17 +1,28 @@
 package org.ticketing.payment.infrastructure.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.ticketing.config.security.CustomAccessDeniedHandler;
+import org.ticketing.config.security.CustomAuthenticationEntryPoint;
+import org.ticketing.config.security.LoginFilter;
 
 @Configuration
+@EnableMethodSecurity
+@RequiredArgsConstructor
 public class PaymentSecurityConfig {
 
-    // MVP 통합 테스트용 임시 SecurityConfig
+    private final LoginFilter loginFilter;
+    private final CustomAuthenticationEntryPoint authenticationEntryPoint;
+    private final CustomAccessDeniedHandler accessDeniedHandler;
+
     @Bean
     @Order(1)
     public SecurityFilterChain paymentFilterChain(HttpSecurity http) throws Exception {
@@ -23,8 +34,13 @@ public class PaymentSecurityConfig {
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
+                .addFilterBefore(loginFilter, UsernamePasswordAuthenticationFilter.class)
                 .authorizeHttpRequests(auth -> auth
-                        .anyRequest().permitAll()
+                        .anyRequest().authenticated()
+                )
+                .exceptionHandling(e -> e
+                        .authenticationEntryPoint(authenticationEntryPoint)
+                        .accessDeniedHandler(accessDeniedHandler)
                 )
                 .build();
     }

--- a/src/main/java/org/ticketing/payment/infrastructure/config/PaymentSecurityConfig.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/config/PaymentSecurityConfig.java
@@ -34,10 +34,11 @@ public class PaymentSecurityConfig {
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
-                .addFilterBefore(loginFilter, UsernamePasswordAuthenticationFilter.class)
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/payment-test.html").permitAll()
                         .anyRequest().authenticated()
                 )
+                .addFilterBefore(loginFilter, UsernamePasswordAuthenticationFilter.class)
                 .exceptionHandling(e -> e
                         .authenticationEntryPoint(authenticationEntryPoint)
                         .accessDeniedHandler(accessDeniedHandler)

--- a/src/main/java/org/ticketing/payment/infrastructure/feign/ReservationFeignClient.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/feign/ReservationFeignClient.java
@@ -1,0 +1,14 @@
+package org.ticketing.payment.infrastructure.feign;
+
+import java.util.UUID;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.ticketing.payment.infrastructure.feign.dto.InternalReservationResponse;
+
+@FeignClient(name = "reservation-service")
+public interface ReservationFeignClient {
+
+    @GetMapping("/internal/reservations/{reservationId}")
+    InternalReservationResponse getReservation(@PathVariable UUID reservationId);
+}

--- a/src/main/java/org/ticketing/payment/infrastructure/feign/ReservationProviderImpl.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/feign/ReservationProviderImpl.java
@@ -1,8 +1,10 @@
 package org.ticketing.payment.infrastructure.feign;
 
+import feign.FeignException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.ticketing.payment.domain.exception.ReservationNotFoundException;
 import org.ticketing.payment.domain.provider.ReservationProvider;
 import org.ticketing.payment.infrastructure.feign.dto.InternalReservationResponse;
 
@@ -12,13 +14,23 @@ public class ReservationProviderImpl implements ReservationProvider {
 
     private final ReservationFeignClient reservationFeignClient;
 
+    /**
+     * @throws ReservationNotFoundException 예약이 존재하지 않는 경우 (404)
+     * @throws RuntimeException             그 외 인프라 장애
+     */
     @Override
     public ReservationSnapshot getReservation(UUID reservationId) {
-        InternalReservationResponse response = reservationFeignClient.getReservation(reservationId);
-        return new ReservationSnapshot(
-                response.getReservationId(),
-                response.getUserId(),
-                response.getTotalPrice()
-        );
+        try {
+            InternalReservationResponse response = reservationFeignClient.getReservation(reservationId);
+            return new ReservationSnapshot(
+                    response.getReservationId(),
+                    response.getUserId(),
+                    response.getTotalPrice()
+            );
+        } catch (FeignException.NotFound e) {
+            throw new ReservationNotFoundException(reservationId);
+        } catch (FeignException e) {
+            throw new RuntimeException("Reservation 서비스 호출 실패: " + e.status(), e);
+        }
     }
 }

--- a/src/main/java/org/ticketing/payment/infrastructure/feign/ReservationProviderImpl.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/feign/ReservationProviderImpl.java
@@ -1,0 +1,24 @@
+package org.ticketing.payment.infrastructure.feign;
+
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.ticketing.payment.domain.provider.ReservationProvider;
+import org.ticketing.payment.infrastructure.feign.dto.InternalReservationResponse;
+
+@Component
+@RequiredArgsConstructor
+public class ReservationProviderImpl implements ReservationProvider {
+
+    private final ReservationFeignClient reservationFeignClient;
+
+    @Override
+    public ReservationSnapshot getReservation(UUID reservationId) {
+        InternalReservationResponse response = reservationFeignClient.getReservation(reservationId);
+        return new ReservationSnapshot(
+                response.getReservationId(),
+                response.getUserId(),
+                response.getTotalPrice()
+        );
+    }
+}

--- a/src/main/java/org/ticketing/payment/infrastructure/feign/dto/InternalReservationResponse.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/feign/dto/InternalReservationResponse.java
@@ -1,0 +1,16 @@
+package org.ticketing.payment.infrastructure.feign.dto;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class InternalReservationResponse {
+
+    private UUID reservationId;
+    private UUID userId;
+    private Long totalPrice;
+}

--- a/src/main/java/org/ticketing/payment/infrastructure/persistence/JpaPaymentRepository.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/persistence/JpaPaymentRepository.java
@@ -12,10 +12,13 @@ import org.ticketing.payment.domain.model.PaymentStatus;
 
 public interface JpaPaymentRepository extends JpaRepository<Payment, UUID> {
     Optional<Payment> findByIdAndDeletedAtIsNull(UUID id);
+    Optional<Payment> findByIdAndUserIdAndDeletedAtIsNull(UUID id, UUID userId);
     Page<Payment> findAllByDeletedAtIsNull(Pageable pageable);
     boolean existsByReservationIdAndStatusIn(UUID reservationId, List<PaymentStatus> statuses);
     Page<Payment> findByReservationIdAndDeletedAtIsNull(UUID reservationId, Pageable pageable);
+    Page<Payment> findByReservationIdAndUserIdAndDeletedAtIsNull(UUID reservationId, UUID userId, Pageable pageable);
     Optional<Payment> findFirstByReservationIdAndStatusAndDeletedAtIsNullOrderByCreatedAtDesc(UUID reservationId, PaymentStatus status);
+    Optional<Payment> findFirstByReservationIdAndUserIdAndStatusAndDeletedAtIsNullOrderByCreatedAtDesc(UUID reservationId, UUID userId, PaymentStatus status);
     Page<Payment> findByUserIdAndDeletedAtIsNull(UUID userId, Pageable pageable);
     List<Payment> findByStatusAndModifiedAtBeforeAndDeletedAtIsNull(PaymentStatus status, LocalDateTime before);
 }

--- a/src/main/java/org/ticketing/payment/infrastructure/persistence/PaymentRepositoryImpl.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/persistence/PaymentRepositoryImpl.java
@@ -28,6 +28,11 @@ public class PaymentRepositoryImpl implements PaymentRepository {
     }
 
     @Override
+    public Optional<Payment> findByIdAndUserId(UUID id, UUID userId) {
+        return jpaPaymentRepository.findByIdAndUserIdAndDeletedAtIsNull(id, userId);
+    }
+
+    @Override
     public Page<Payment> findAll(Pageable pageable) {
         return jpaPaymentRepository.findAllByDeletedAtIsNull(pageable);
     }
@@ -44,8 +49,18 @@ public class PaymentRepositoryImpl implements PaymentRepository {
     }
 
     @Override
+    public Page<Payment> findByReservationIdAndUserId(UUID reservationId, UUID userId, Pageable pageable) {
+        return jpaPaymentRepository.findByReservationIdAndUserIdAndDeletedAtIsNull(reservationId, userId, pageable);
+    }
+
+    @Override
     public Optional<Payment> findSuccessPaymentByReservationId(UUID reservationId) {
         return jpaPaymentRepository.findFirstByReservationIdAndStatusAndDeletedAtIsNullOrderByCreatedAtDesc(reservationId, PaymentStatus.SUCCESS);
+    }
+
+    @Override
+    public Optional<Payment> findSuccessPaymentByReservationIdAndUserId(UUID reservationId, UUID userId) {
+        return jpaPaymentRepository.findFirstByReservationIdAndUserIdAndStatusAndDeletedAtIsNullOrderByCreatedAtDesc(reservationId, userId, PaymentStatus.SUCCESS);
     }
 
     @Override

--- a/src/main/java/org/ticketing/payment/infrastructure/toss/MockTossPaymentProvider.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/toss/MockTossPaymentProvider.java
@@ -1,0 +1,31 @@
+package org.ticketing.payment.infrastructure.toss;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.ticketing.payment.domain.provider.TossPaymentProvider;
+
+@Component
+@Profile("loadtest")
+public class MockTossPaymentProvider implements TossPaymentProvider {
+
+    @Override
+    public ConfirmResult confirm(String paymentKey, String orderId, Long amount) {
+        // Toss API 호출 없이 바로 성공 응답 반환
+        return new ConfirmResult(paymentKey, orderId, "DONE", amount);
+    }
+
+    @Override
+    public void cancel(String paymentKey, String cancelReason) {
+        // no operation
+    }
+
+    @Override
+    public StatusResult getByOrderId(String orderId) {
+        return new StatusResult("mock_pk_" + orderId, orderId, "DONE", 0L);
+    }
+
+    @Override
+    public StatusResult getByPaymentKey(String paymentKey) {
+        return new StatusResult(paymentKey, "mock_order", "DONE", 0L);
+    }
+}

--- a/src/main/java/org/ticketing/payment/infrastructure/toss/TossPaymentProviderImpl.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/toss/TossPaymentProviderImpl.java
@@ -1,0 +1,52 @@
+package org.ticketing.payment.infrastructure.toss;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.ticketing.payment.domain.provider.TossPaymentProvider;
+import org.ticketing.payment.infrastructure.toss.dto.TossConfirmResponse;
+import org.ticketing.payment.infrastructure.toss.dto.TossPaymentStatusResponse;
+
+@Component
+@RequiredArgsConstructor
+public class TossPaymentProviderImpl implements TossPaymentProvider {
+
+    private final TossPaymentClient tossPaymentClient;
+
+    @Override
+    public ConfirmResult confirm(String paymentKey, String orderId, Long amount) {
+        TossConfirmResponse response = tossPaymentClient.confirm(paymentKey, orderId, amount);
+        return new ConfirmResult(
+                response.getPaymentKey(),
+                response.getOrderId(),
+                response.getStatus(),
+                response.getTotalAmount()
+        );
+    }
+
+    @Override
+    public void cancel(String paymentKey, String cancelReason) {
+        tossPaymentClient.cancel(paymentKey, cancelReason);
+    }
+
+    @Override
+    public StatusResult getByOrderId(String orderId) {
+        TossPaymentStatusResponse response = tossPaymentClient.getByOrderId(orderId);
+        return new StatusResult(
+                response.getPaymentKey(),
+                response.getOrderId(),
+                response.getStatus(),
+                response.getTotalAmount()
+        );
+    }
+
+    @Override
+    public StatusResult getByPaymentKey(String paymentKey) {
+        TossPaymentStatusResponse response = tossPaymentClient.getByPaymentKey(paymentKey);
+        return new StatusResult(
+                response.getPaymentKey(),
+                response.getOrderId(),
+                response.getStatus(),
+                response.getTotalAmount()
+        );
+    }
+}

--- a/src/main/java/org/ticketing/payment/infrastructure/toss/TossPaymentProviderImpl.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/toss/TossPaymentProviderImpl.java
@@ -1,12 +1,14 @@
 package org.ticketing.payment.infrastructure.toss;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.ticketing.payment.domain.provider.TossPaymentProvider;
 import org.ticketing.payment.infrastructure.toss.dto.TossConfirmResponse;
 import org.ticketing.payment.infrastructure.toss.dto.TossPaymentStatusResponse;
 
 @Component
+@Profile("!loadtest")
 @RequiredArgsConstructor
 public class TossPaymentProviderImpl implements TossPaymentProvider {
 

--- a/src/main/java/org/ticketing/payment/presentation/controller/PaymentController.java
+++ b/src/main/java/org/ticketing/payment/presentation/controller/PaymentController.java
@@ -6,12 +6,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.ticketing.common.util.SecurityUtil;
 import org.ticketing.payment.application.service.PaymentService;
 import org.ticketing.payment.presentation.dto.request.CreatePaymentRequestDto;
 import org.ticketing.payment.presentation.dto.request.PaymentSuccessRequestDto;
@@ -30,13 +32,15 @@ public class PaymentController {
     // (사용자가 결제 요청 버튼 누를 때)
     @PostMapping
     public PaymentResponseDto createPayment(@RequestBody @Valid CreatePaymentRequestDto request) {
-        return PaymentResponseDto.from(paymentService.createPayment(request.toCommand()));
+        UUID userId = SecurityUtil.getCurrentUserIdOrThrow();
+        return PaymentResponseDto.from(paymentService.createPayment(request.toCommand(userId)));
     }
 
     // paymentId에 따른 결제 정보 조회 [Customer]
     @GetMapping("/my/{paymentId}")
     public PaymentResponseDto getMyPayment(@PathVariable @NotNull UUID paymentId) {
-        return PaymentResponseDto.from(paymentService.getPayment(paymentId));
+        UUID userId = SecurityUtil.getCurrentUserIdOrThrow();
+        return PaymentResponseDto.from(paymentService.getMyPayment(userId, paymentId));
     }
 
     // reservationId에 따른 결제 정보 조회 [Customer]
@@ -44,22 +48,26 @@ public class PaymentController {
     public Page<PaymentResponseDto> getMyPaymentsByReservationId(
             @PathVariable @NotNull UUID reservationId,
             @PageableDefault(size = 10, sort = "createdAt") Pageable pageable) {
-        return paymentService.getPaymentsByReservationId(reservationId, pageable).map(PaymentResponseDto::from);
+        UUID userId = SecurityUtil.getCurrentUserIdOrThrow();
+        return paymentService.getMyPaymentsByReservationId(userId, reservationId, pageable).map(PaymentResponseDto::from);
     }
 
     // reservationId에 따른 성공 결제 정보 조회 [Customer]
     @GetMapping("/my/reservations/{reservationId}/success")
     public PaymentResponseDto getMySuccessPaymentByReservationId(@PathVariable @NotNull UUID reservationId) {
-        return PaymentResponseDto.from(paymentService.getSuccessPaymentByReservationId(reservationId));
+        UUID userId = SecurityUtil.getCurrentUserIdOrThrow();
+        return PaymentResponseDto.from(paymentService.getMySuccessPaymentByReservationId(userId, reservationId));
     }
 
     // paymentId에 따른 결제 정보 조회 [Admin]
+    @PreAuthorize("hasRole('ADMIN')")
     @GetMapping("/{paymentId}")
     public PaymentResponseDto getPayment(@PathVariable @NotNull UUID paymentId) {
         return PaymentResponseDto.from(paymentService.getPayment(paymentId));
     }
 
     // reservationId에 따른 결제 정보 조회 [Admin]
+    @PreAuthorize("hasRole('ADMIN')")
     @GetMapping("/reservations/{reservationId}")
     public Page<PaymentResponseDto> getPaymentsByReservationId(
             @PathVariable @NotNull UUID reservationId,
@@ -68,22 +76,25 @@ public class PaymentController {
     }
 
     // 전체 결제 정보 조회 [Admin]
+    @PreAuthorize("hasRole('ADMIN')")
     @GetMapping
     public Page<PaymentResponseDto> getPayments(
             @PageableDefault(size = 10, sort = "createdAt") Pageable pageable) {
         return paymentService.getPayments(pageable).map(PaymentResponseDto::from);
     }
 
-    // 결제 환불 [Customer]
+    // 결제 환불 [Admin]
+    @PreAuthorize("hasRole('ADMIN')")
     @PostMapping("/refund/reservations/{reservationId}")
     public PaymentResponseDto refundPayment(@PathVariable @NotNull UUID reservationId) {
         return PaymentResponseDto.from(paymentService.refundPayment(reservationId));
     }
 
-    // 결제 승인 [PG]
+    // 결제 승인 [Customer]
     @PostMapping("/success")
     public PaymentResponseDto confirmPayment(
             @RequestBody @Valid PaymentSuccessRequestDto request) {
-        return PaymentResponseDto.from(paymentService.confirmPayment(request.toCommand()));
+        UUID userId = SecurityUtil.getCurrentUserIdOrThrow();
+        return PaymentResponseDto.from(paymentService.confirmPayment(request.toCommand(userId)));
     }
 }

--- a/src/main/java/org/ticketing/payment/presentation/controller/PaymentInternalController.java
+++ b/src/main/java/org/ticketing/payment/presentation/controller/PaymentInternalController.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,6 +15,7 @@ import org.ticketing.payment.presentation.dto.response.PaymentResponseDto;
 
 import java.util.UUID;
 
+@PreAuthorize("hasRole('INTERNAL')")
 @RestController
 @RequestMapping("/internal/payments")
 @RequiredArgsConstructor

--- a/src/main/java/org/ticketing/payment/presentation/dto/request/CreatePaymentRequestDto.java
+++ b/src/main/java/org/ticketing/payment/presentation/dto/request/CreatePaymentRequestDto.java
@@ -19,11 +19,7 @@ public class CreatePaymentRequestDto {
     @NotNull
     private UUID reservationId;
 
-    @NotNull
-    @Positive
-    private Long totalPrice;
-
     public CreatePaymentCommand toCommand() {
-        return new CreatePaymentCommand(userId, reservationId, totalPrice);
+        return new CreatePaymentCommand(userId, reservationId);
     }
 }

--- a/src/main/java/org/ticketing/payment/presentation/dto/request/CreatePaymentRequestDto.java
+++ b/src/main/java/org/ticketing/payment/presentation/dto/request/CreatePaymentRequestDto.java
@@ -14,12 +14,9 @@ import org.ticketing.payment.application.dto.command.CreatePaymentCommand;
 public class CreatePaymentRequestDto {
 
     @NotNull
-    private UUID userId;
-
-    @NotNull
     private UUID reservationId;
 
-    public CreatePaymentCommand toCommand() {
+    public CreatePaymentCommand toCommand(UUID userId) {
         return new CreatePaymentCommand(userId, reservationId);
     }
 }

--- a/src/main/java/org/ticketing/payment/presentation/dto/request/PaymentSuccessRequestDto.java
+++ b/src/main/java/org/ticketing/payment/presentation/dto/request/PaymentSuccessRequestDto.java
@@ -24,7 +24,7 @@ public class PaymentSuccessRequestDto {
     @Positive
     private Long totalPrice;
 
-    public ConfirmPaymentCommand toCommand() {
-        return new ConfirmPaymentCommand(paymentKey, paymentId, totalPrice);
+    public ConfirmPaymentCommand toCommand(UUID userId) {
+        return new ConfirmPaymentCommand(userId, paymentKey, paymentId, totalPrice);
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -7,8 +7,3 @@ spring:
 
   config:
     import: "optional:configserver:http://${CONFIG_SERVER_HOST:localhost}:${CONFIG_SERVER_PORT:10002}"
-
-eureka:
-  client:
-    service-url:
-      defaultZone: ${EUREKA_DEFAULT_ZONE:http://localhost:10001/eureka/}

--- a/src/main/resources/static/payment-test.html
+++ b/src/main/resources/static/payment-test.html
@@ -37,10 +37,7 @@
     }
     button:hover { background: #1b6fe3; }
     button:disabled { background: #aaa; cursor: not-allowed; }
-    .btn-toss {
-      background: #3182f6;
-      margin-top: 8px;
-    }
+    .btn-toss { background: #3182f6; margin-top: 8px; }
     .btn-confirm { background: #00b386; }
     .btn-confirm:hover { background: #009970; }
     .btn-cancel { background: #e53935; }
@@ -66,6 +63,8 @@
       margin-left: 8px;
       vertical-align: middle;
     }
+    .badge.admin { background: #fce4ec; color: #c62828; }
+    .badge.internal { background: #f3e5f5; color: #6a1b9a; }
     .step { font-size: 12px; color: #999; margin-bottom: 6px; }
     hr { border: none; border-top: 1px solid #eee; margin: 6px 0 10px; }
     .notice {
@@ -77,11 +76,61 @@
       padding: 8px 10px;
       margin-top: 8px;
     }
+    .section-divider {
+      display: flex;
+      align-items: center;
+      margin: 24px 0 16px;
+      gap: 10px;
+    }
+    .section-divider span {
+      font-size: 13px;
+      font-weight: 700;
+      padding: 4px 14px;
+      border-radius: 20px;
+      white-space: nowrap;
+    }
+    .section-divider.customer span { background: #e3f2fd; color: #1565c0; }
+    .section-divider.admin span { background: #fce4ec; color: #b71c1c; }
+    .section-divider::after {
+      content: '';
+      flex: 1;
+      height: 1px;
+      background: #ddd;
+    }
   </style>
 </head>
 <body>
 
 <h2 style="font-size:20px;margin-bottom:20px;">🧪 결제 테스트</h2>
+
+<!-- 환경 설정 -->
+<div class="card">
+  <h2>환경 설정</h2>
+  <hr/>
+  <label>Base URL (호출 대상 서버)</label>
+  <input id="baseUrl" value="http://localhost:20006" placeholder="http://localhost:20006" />
+  <div style="display:flex;gap:8px;margin-top:8px;">
+    <button style="margin-top:0;flex:1;padding:6px;font-size:12px;background:#555;" onclick="setBase('http://localhost:20006')">payment-service (20006)</button>
+    <button style="margin-top:0;flex:1;padding:6px;font-size:12px;background:#555;" onclick="setBase('http://localhost:10000')">gateway (10000)</button>
+  </div>
+</div>
+
+<!-- Keycloak 토큰 발급 -->
+<div class="card">
+  <h2>Keycloak 토큰 발급</h2>
+  <hr/>
+  <label>Keycloak URL</label>
+  <input id="keycloakUrl" value="http://localhost:18080" />
+  <label>Username</label>
+  <input id="kcUsername" placeholder="user@example.com" />
+  <label>Password</label>
+  <input id="kcPassword" type="password" placeholder="password" />
+  <button onclick="fetchToken()" style="background:#7b1fa2;">토큰 발급</button>
+  <div id="tokenResult"></div>
+  <label style="margin-top:12px;">JWT Bearer Token (자동 입력 또는 직접 붙여넣기)</label>
+  <input id="jwtToken" placeholder="eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9..." />
+  <div class="notice">⚠ userId는 JWT 토큰에서 서버가 추출합니다. 요청 body에 userId를 넣지 않습니다.</div>
+</div>
 
 <!-- Toss 클라이언트 키 설정 -->
 <div class="card">
@@ -92,35 +141,25 @@
   <div class="notice">⚠ 이 키는 브라우저에서만 사용되며 서버로 전송되지 않습니다.</div>
 </div>
 
-<!-- STEP 1 -->
+<!-- ===== CUSTOMER 섹션 ===== -->
+<div class="section-divider customer"><span>👤 Customer 권한</span></div>
+
+<!-- STEP 1+2 -->
 <div class="card">
   <div class="step">STEP 1</div>
-  <h2>결제 생성 <span class="badge">POST /api/payments</span></h2>
+  <h2>결제 생성 + Toss 결제창 <span class="badge">POST /api/payments</span></h2>
   <hr/>
-  <label>userId (UUID)</label>
-  <input id="userId" value="11111111-1111-1111-1111-111111111111" />
-  <label>reservationId (UUID) — Toss orderId로 사용됨</label>
+  <label>reservationId (UUID)</label>
   <input id="reservationId" value="22222222-2222-2222-2222-222222222222" />
-  <label>totalPrice (원)</label>
-  <input id="totalPrice" type="number" value="50000" />
-  <button onclick="createPayment()">1. 결제 생성</button>
+  <input id="paymentId" type="hidden" />
+  <button class="btn-toss" onclick="startPayment()">결제 생성 후 Toss 결제창 열기</button>
+  <div class="notice">결제 생성 응답 확인 후 Toss 결제창으로 이동합니다. 완료 후 이 페이지로 돌아와 paymentKey가 자동 입력됩니다.</div>
   <div id="createResult"></div>
 </div>
 
 <!-- STEP 2 -->
 <div class="card">
   <div class="step">STEP 2</div>
-  <h2>Toss 결제창 호출</h2>
-  <hr/>
-  <label>paymentId (STEP 1에서 자동 입력, 또는 직접 붙여넣기)</label>
-  <input id="paymentId" placeholder="결제 생성 후 자동 입력" />
-  <button class="btn-toss" onclick="openToss()">2. Toss 결제창 열기</button>
-  <div class="notice">결제 완료 후 이 페이지로 돌아와 paymentKey가 자동 입력됩니다.</div>
-</div>
-
-<!-- STEP 3 -->
-<div class="card">
-  <div class="step">STEP 3</div>
   <h2>결제 승인 확인 <span class="badge">POST /api/payments/success</span></h2>
   <hr/>
   <label>paymentKey (body)</label>
@@ -129,33 +168,147 @@
   <input id="confirmPaymentId" placeholder="결제 생성 후 자동 입력" />
   <label>totalPrice (body)</label>
   <input id="confirmPrice" type="number" placeholder="STEP 1에서 입력한 totalPrice" />
-  <button class="btn-confirm" onclick="confirmPayment()">3. 결제 승인 요청</button>
+  <button class="btn-confirm" onclick="confirmPayment()">2. 결제 승인 요청</button>
   <div id="confirmResult"></div>
 </div>
 
-<!-- 조회 / 취소 -->
+<!-- 내 결제 단건 조회 -->
 <div class="card">
-  <div class="step">조회 / 취소</div>
-  <h2>결제 단건 조회 <span class="badge">GET /api/payments/{id}</span></h2>
+  <div class="step">Customer 조회</div>
+  <h2>내 결제 단건 조회 <span class="badge">GET /api/payments/my/{paymentId}</span></h2>
   <hr/>
   <label>paymentId</label>
-  <input id="getPaymentId" placeholder="자동 입력" />
-  <button onclick="getPayment()">조회</button>
-  <div id="getResult"></div>
+  <input id="myGetPaymentId" placeholder="자동 입력" />
+  <button onclick="getMyPayment()">내 결제 조회</button>
+  <div id="myGetResult"></div>
 </div>
 
+<!-- 내 결제 목록 (reservationId 기준) -->
 <div class="card">
-  <div class="step">조회 / 취소</div>
-  <h2>결제 취소 <span class="badge">POST /api/payments/refund/reservations/{reservationId}</span></h2>
+  <div class="step">Customer 조회</div>
+  <h2>내 결제 목록 조회 <span class="badge">GET /api/payments/my/reservations/{reservationId}</span></h2>
+  <hr/>
+  <label>reservationId</label>
+  <input id="myReservationId" placeholder="자동 입력" />
+  <label>page (0부터)</label>
+  <input id="myReservationPage" type="number" value="0" />
+  <label>size</label>
+  <input id="myReservationSize" type="number" value="10" />
+  <button onclick="getMyPaymentsByReservation()">내 결제 목록 조회</button>
+  <div id="myReservationResult"></div>
+</div>
+
+<!-- 내 성공 결제 조회 (reservationId 기준) -->
+<div class="card">
+  <div class="step">Customer 조회</div>
+  <h2>내 성공 결제 조회 <span class="badge">GET /api/payments/my/reservations/{reservationId}/success</span></h2>
+  <hr/>
+  <label>reservationId</label>
+  <input id="mySuccessReservationId" placeholder="자동 입력" />
+  <button onclick="getMySuccessPayment()">내 성공 결제 조회</button>
+  <div id="mySuccessResult"></div>
+</div>
+
+<!-- ===== ADMIN 섹션 ===== -->
+<div class="section-divider admin"><span>🔑 Admin 권한</span></div>
+
+<!-- 결제 단건 조회 (Admin) -->
+<div class="card">
+  <div class="step">Admin 조회</div>
+  <h2>결제 단건 조회 <span class="badge admin">GET /api/payments/{paymentId}</span></h2>
   <hr/>
   <label>paymentId</label>
-  <input id="cancelReservationId" placeholder="자동 입력" />
-  <button class="btn-cancel" onclick="cancelPayment()">결제 취소</button>
-  <div id="cancelResult"></div>
+  <input id="adminGetPaymentId" placeholder="자동 입력" />
+  <button onclick="adminGetPayment()">조회</button>
+  <div id="adminGetResult"></div>
+</div>
+
+<!-- 전체 결제 목록 조회 (Admin) -->
+<div class="card">
+  <div class="step">Admin 조회</div>
+  <h2>전체 결제 목록 조회 <span class="badge admin">GET /api/payments</span></h2>
+  <hr/>
+  <label>page (0부터)</label>
+  <input id="adminListPage" type="number" value="0" />
+  <label>size</label>
+  <input id="adminListSize" type="number" value="10" />
+  <button onclick="adminGetPayments()">전체 조회</button>
+  <div id="adminListResult"></div>
+</div>
+
+<!-- reservationId에 따른 결제 목록 조회 (Admin) -->
+<div class="card">
+  <div class="step">Admin 조회</div>
+  <h2>예약별 결제 목록 조회 <span class="badge admin">GET /api/payments/reservations/{reservationId}</span></h2>
+  <hr/>
+  <label>reservationId</label>
+  <input id="adminReservationId" placeholder="자동 입력" />
+  <label>page (0부터)</label>
+  <input id="adminReservationPage" type="number" value="0" />
+  <label>size</label>
+  <input id="adminReservationSize" type="number" value="10" />
+  <button onclick="adminGetPaymentsByReservation()">예약별 결제 목록 조회</button>
+  <div id="adminReservationResult"></div>
+</div>
+
+<!-- 결제 환불 (Admin) -->
+<div class="card">
+  <div class="step">Admin 환불</div>
+  <h2>결제 환불 <span class="badge admin">POST /api/payments/refund/reservations/{reservationId}</span></h2>
+  <hr/>
+  <label>reservationId</label>
+  <input id="refundReservationId" placeholder="자동 입력" />
+  <button class="btn-cancel" onclick="refundPayment()">결제 환불</button>
+  <div id="refundResult"></div>
 </div>
 
 <script>
-  const BASE = '';
+  async function fetchToken() {
+    const keycloakUrl = (document.getElementById('keycloakUrl').value || '').replace(/\/$/, '');
+    const username = document.getElementById('kcUsername').value.trim();
+    const password = document.getElementById('kcPassword').value;
+
+    if (!username || !password) { show('tokenResult', { error: 'username과 password를 입력하세요.' }, 'err'); return; }
+
+    const tokenUrl = `${keycloakUrl}/realms/ticketing/protocol/openid-connect/token`;
+    const body = new URLSearchParams({
+      grant_type: 'password',
+      client_id: 'ticketing-client',
+      username,
+      password,
+    });
+
+    let res, text;
+    try {
+      res = await fetch(tokenUrl, { method: 'POST', body, headers: { 'Content-Type': 'application/x-www-form-urlencoded' } });
+      text = await res.text();
+    } catch (e) {
+      show('tokenResult', { error: '네트워크 오류', message: e.message, url: tokenUrl }, 'err'); return;
+    }
+
+    let json;
+    try { json = JSON.parse(text); } catch { show('tokenResult', { error: text }, 'err'); return; }
+
+    if (!res.ok) { show('tokenResult', json, 'err'); return; }
+
+    document.getElementById('jwtToken').value = json.access_token;
+    show('tokenResult', { message: '토큰 발급 성공. JWT 필드에 자동 입력됐습니다.', expires_in: json.expires_in }, 'ok');
+  }
+
+  function getBase() {
+    return (document.getElementById('baseUrl').value || '').replace(/\/$/, '');
+  }
+
+  function setBase(url) {
+    document.getElementById('baseUrl').value = url;
+  }
+
+  function getAuthHeaders() {
+    const token = document.getElementById('jwtToken').value.trim();
+    const headers = { 'Content-Type': 'application/json' };
+    if (token) headers['Authorization'] = 'Bearer ' + token;
+    return headers;
+  }
 
   function show(elId, data, type = 'ok') {
     const el = document.getElementById(elId);
@@ -164,60 +317,63 @@
   }
 
   async function request(method, path, body) {
-    const opts = { method, headers: { 'Content-Type': 'application/json' } };
+    const opts = { method, headers: getAuthHeaders() };
     if (body) opts.body = JSON.stringify(body);
-    const res = await fetch(BASE + path, opts);
-    const text = await res.text();
+    let res, text;
+    try {
+      res = await fetch(getBase() + path, opts);
+      text = await res.text();
+    } catch (e) {
+      return { ok: false, data: { error: '네트워크 오류', message: e.message, url: getBase() + path } };
+    }
     try { return { ok: res.ok, data: JSON.parse(text) }; }
     catch { return { ok: res.ok, data: text }; }
   }
 
-  async function createPayment() {
-    const userId = document.getElementById('userId').value.trim();
-    const reservationId = document.getElementById('reservationId').value.trim();
-    const totalPrice = Number(document.getElementById('totalPrice').value);
-    if (!userId || !reservationId || !totalPrice) {
-      show('createResult', { error: '모든 필드를 입력하세요.' }, 'err'); return;
-    }
-    const { ok, data } = await request('POST', '/api/payments', { userId, reservationId, totalPrice });
-    show('createResult', data, ok ? 'ok' : 'err');
-    if (ok && data.id) {
-      document.getElementById('paymentId').value = data.id;
-      document.getElementById('getPaymentId').value = data.id;
-      document.getElementById('cancelReservationId').value = reservationId;
-      document.getElementById('confirmPaymentId').value = data.id;
-      document.getElementById('confirmPrice').value = totalPrice;
-      // Toss 리다이렉트 후 복원용
-      localStorage.setItem('toss_paymentId', data.id);
-      localStorage.setItem('toss_totalPrice', String(totalPrice));
-    }
-  }
+  // ===== Customer =====
 
-  function openToss() {
+  async function startPayment() {
+    const reservationId = document.getElementById('reservationId').value.trim();
     const clientKey = document.getElementById('clientKey').value.trim();
-    const paymentId = document.getElementById('paymentId').value.trim();
-    const reservationId = document.getElementById('reservationId').value.trim();
-    const totalPrice = Number(document.getElementById('totalPrice').value);
 
-    if (!clientKey) { alert('Toss 클라이언트 키를 입력하세요.'); return; }
-    // 입력값 없으면 sessionStorage 폴백
-    const resolvedPaymentId = paymentId || localStorage.getItem('toss_paymentId') || '';
-    if (!resolvedPaymentId) { alert('먼저 결제를 생성하세요. (STEP 1)'); return; }
-    document.getElementById('paymentId').value = resolvedPaymentId;
-    if (!totalPrice) { alert('totalPrice를 확인하세요.'); return; }
+    if (!reservationId) { show('createResult', { error: 'reservationId를 입력하세요.' }, 'err'); return; }
+    if (!clientKey) { show('createResult', { error: 'Toss 클라이언트 키를 위에서 먼저 입력하세요.' }, 'err'); return; }
 
-    const tossPayments = TossPayments(clientKey);
-    const successUrl = window.location.href.split('?')[0] + '?success=1';
-    const failUrl    = window.location.href.split('?')[0] + '?fail=1';
+    const { ok, data } = await request('POST', '/api/payments', { reservationId });
+    show('createResult', data, ok ? 'ok' : 'err');
+    if (!ok) return;
+    if (!data.id) { show('createResult', { ...data, _warn: '결제 id가 없습니다. 응답을 확인하세요.' }, 'err'); return; }
 
-    tossPayments.requestPayment('카드', {
-      amount: totalPrice,
-      orderId: resolvedPaymentId,
-      orderName: '티켓 결제 테스트',
-      successUrl,
-      failUrl,
-      customerName: '테스트유저',
-    });
+    const paymentId = data.id;
+    const totalPrice = data.totalPrice;
+
+    document.getElementById('paymentId').value = paymentId;
+    document.getElementById('confirmPaymentId').value = paymentId;
+    document.getElementById('confirmPrice').value = totalPrice;
+    document.getElementById('myGetPaymentId').value = paymentId;
+    document.getElementById('adminGetPaymentId').value = paymentId;
+    document.getElementById('myReservationId').value = reservationId;
+    document.getElementById('mySuccessReservationId').value = reservationId;
+    document.getElementById('adminReservationId').value = reservationId;
+    document.getElementById('refundReservationId').value = reservationId;
+    localStorage.setItem('toss_paymentId', paymentId);
+    localStorage.setItem('toss_totalPrice', String(totalPrice));
+
+    try {
+      const tossPayments = TossPayments(clientKey);
+      const successUrl = window.location.href.split('?')[0] + '?success=1';
+      const failUrl    = window.location.href.split('?')[0] + '?fail=1';
+      tossPayments.requestPayment('카드', {
+        amount: totalPrice,
+        orderId: paymentId,
+        orderName: '티켓 결제 테스트',
+        successUrl,
+        failUrl,
+        customerName: '테스트유저',
+      });
+    } catch (e) {
+      show('createResult', { ...data, _tossError: e.message }, 'err');
+    }
   }
 
   async function confirmPayment() {
@@ -236,26 +392,67 @@
     show('confirmResult', data, ok ? 'ok' : 'err');
   }
 
-  async function getPayment() {
-    const paymentId = document.getElementById('getPaymentId').value.trim();
-    if (!paymentId) { show('getResult', { error: 'paymentId를 입력하세요.' }, 'err'); return; }
-    const { ok, data } = await request('GET', `/api/payments/${paymentId}`);
-    show('getResult', data, ok ? 'ok' : 'err');
+  async function getMyPayment() {
+    const paymentId = document.getElementById('myGetPaymentId').value.trim();
+    if (!paymentId) { show('myGetResult', { error: 'paymentId를 입력하세요.' }, 'err'); return; }
+    const { ok, data } = await request('GET', `/api/payments/my/${paymentId}`);
+    show('myGetResult', data, ok ? 'ok' : 'err');
   }
 
-  async function cancelPayment() {
-    const reservationId = document.getElementById('cancelReservationId').value.trim();
-    if (!reservationId) { show('cancelResult', { error: 'reservationId 입력하세요.' }, 'err'); return; }
-    if (!confirm('정말 취소하시겠어요?')) return;
+  async function getMyPaymentsByReservation() {
+    const reservationId = document.getElementById('myReservationId').value.trim();
+    if (!reservationId) { show('myReservationResult', { error: 'reservationId를 입력하세요.' }, 'err'); return; }
+    const page = document.getElementById('myReservationPage').value || 0;
+    const size = document.getElementById('myReservationSize').value || 10;
+    const { ok, data } = await request('GET', `/api/payments/my/reservations/${reservationId}?page=${page}&size=${size}`);
+    show('myReservationResult', data, ok ? 'ok' : 'err');
+  }
+
+  async function getMySuccessPayment() {
+    const reservationId = document.getElementById('mySuccessReservationId').value.trim();
+    if (!reservationId) { show('mySuccessResult', { error: 'reservationId를 입력하세요.' }, 'err'); return; }
+    const { ok, data } = await request('GET', `/api/payments/my/reservations/${reservationId}/success`);
+    show('mySuccessResult', data, ok ? 'ok' : 'err');
+  }
+
+  // ===== Admin =====
+
+  async function adminGetPayment() {
+    const paymentId = document.getElementById('adminGetPaymentId').value.trim();
+    if (!paymentId) { show('adminGetResult', { error: 'paymentId를 입력하세요.' }, 'err'); return; }
+    const { ok, data } = await request('GET', `/api/payments/${paymentId}`);
+    show('adminGetResult', data, ok ? 'ok' : 'err');
+  }
+
+  async function adminGetPayments() {
+    const page = document.getElementById('adminListPage').value || 0;
+    const size = document.getElementById('adminListSize').value || 10;
+    const { ok, data } = await request('GET', `/api/payments?page=${page}&size=${size}`);
+    show('adminListResult', data, ok ? 'ok' : 'err');
+  }
+
+  async function adminGetPaymentsByReservation() {
+    const reservationId = document.getElementById('adminReservationId').value.trim();
+    if (!reservationId) { show('adminReservationResult', { error: 'reservationId를 입력하세요.' }, 'err'); return; }
+    const page = document.getElementById('adminReservationPage').value || 0;
+    const size = document.getElementById('adminReservationSize').value || 10;
+    const { ok, data } = await request('GET', `/api/payments/reservations/${reservationId}?page=${page}&size=${size}`);
+    show('adminReservationResult', data, ok ? 'ok' : 'err');
+  }
+
+  async function refundPayment() {
+    const reservationId = document.getElementById('refundReservationId').value.trim();
+    if (!reservationId) { show('refundResult', { error: 'reservationId를 입력하세요.' }, 'err'); return; }
+    if (!confirm('정말 환불하시겠어요?')) return;
     const { ok, data } = await request('POST', `/api/payments/refund/reservations/${reservationId}`);
-    show('cancelResult', data, ok ? 'ok' : 'err');
+    show('refundResult', data, ok ? 'ok' : 'err');
   }
 
   // Toss 리다이렉트 후 쿼리 파라미터 자동 파싱
   (function handleRedirect() {
     const params = new URLSearchParams(window.location.search);
     const paymentKey = params.get('paymentKey');
-    const orderId    = params.get('orderId');    // = payment.id
+    const orderId    = params.get('orderId');
     const amount     = params.get('amount');
     const fail       = params.get('fail');
 
@@ -268,21 +465,20 @@
     }
 
     if (paymentKey && orderId && amount) {
-      const paymentId  = orderId; // Toss orderId = payment.id
+      const paymentId  = orderId;
       const totalPrice = localStorage.getItem('toss_totalPrice') || amount;
 
-      document.getElementById('paymentKey').value    = paymentKey;
+      document.getElementById('paymentKey').value       = paymentKey;
       document.getElementById('confirmPaymentId').value = paymentId;
-      document.getElementById('confirmPrice').value  = totalPrice;
-      document.getElementById('paymentId').value     = paymentId;
-      document.getElementById('getPaymentId').value  = paymentId;
-      document.getElementById('cancelReservationId').value = document.getElementById('reservationId').value;
+      document.getElementById('confirmPrice').value     = totalPrice;
+      document.getElementById('paymentId').value        = paymentId;
+      document.getElementById('myGetPaymentId').value   = paymentId;
+      document.getElementById('adminGetPaymentId').value = paymentId;
 
       show('confirmResult',
         { message: 'Toss 결제 완료! paymentKey가 자동 입력됐습니다. STEP 3에서 승인 요청하세요.', paymentKey },
         'info');
 
-      // URL 클린업
       history.replaceState(null, '', window.location.pathname);
     }
   })();

--- a/src/test/java/org/ticketing/payment/application/service/PaymentServiceTest.java
+++ b/src/test/java/org/ticketing/payment/application/service/PaymentServiceTest.java
@@ -16,6 +16,8 @@ import org.ticketing.payment.domain.exception.PaymentNotFoundException;
 import org.ticketing.payment.domain.model.Payment;
 import org.ticketing.payment.domain.model.PaymentStatus;
 import org.ticketing.payment.domain.repository.PaymentRepository;
+import org.ticketing.payment.infrastructure.feign.ReservationFeignClient;
+import org.ticketing.payment.infrastructure.feign.dto.InternalReservationResponse;
 import org.ticketing.payment.infrastructure.toss.TossPaymentClient;
 import org.ticketing.payment.infrastructure.toss.dto.TossConfirmResponse;
 
@@ -36,6 +38,7 @@ class PaymentServiceTest {
     @Mock PaymentRepository paymentRepository;
     @Mock TossPaymentClient tossPaymentClient;
     @Mock PaymentStatusService paymentStatusService;
+    @Mock ReservationFeignClient reservationFeignClient;
     @InjectMocks PaymentService paymentService;
 
     private static final UUID USER_ID = UUID.randomUUID();
@@ -51,13 +54,17 @@ class PaymentServiceTest {
 
         @BeforeEach
         void setUp() {
-            command = new CreatePaymentCommand(USER_ID, RESERVATION_ID, PRICE);
+            command = new CreatePaymentCommand(USER_ID, RESERVATION_ID);
         }
 
         @Test
         void 정상_생성() {
-            Payment payment = Payment.create(USER_ID, RESERVATION_ID, PRICE);
+            InternalReservationResponse reservationResponse =
+                    new InternalReservationResponse(RESERVATION_ID, USER_ID, PRICE);
+            given(reservationFeignClient.getReservation(RESERVATION_ID)).willReturn(reservationResponse);
             given(paymentRepository.existsActivePayment(RESERVATION_ID)).willReturn(false);
+
+            Payment payment = Payment.create(USER_ID, RESERVATION_ID, PRICE);
             given(paymentRepository.save(any(Payment.class))).willReturn(payment);
 
             PaymentResult result = paymentService.createPayment(command);
@@ -69,12 +76,23 @@ class PaymentServiceTest {
         }
 
         @Test
-        void 결제_정보와_불일치시() {
+        void userId_불일치시_IllegalArgumentException() {
+            UUID otherUserId = UUID.randomUUID();
+            InternalReservationResponse reservationResponse =
+                    new InternalReservationResponse(RESERVATION_ID, otherUserId, PRICE);
+            given(reservationFeignClient.getReservation(RESERVATION_ID)).willReturn(reservationResponse);
 
+            assertThatThrownBy(() -> paymentService.createPayment(command))
+                    .isInstanceOf(IllegalArgumentException.class);
+
+            verify(paymentRepository, never()).save(any());
         }
 
         @Test
         void 동일_예약에_진행중인_결제_존재시_DuplicatePaymentException() {
+            InternalReservationResponse reservationResponse =
+                    new InternalReservationResponse(RESERVATION_ID, USER_ID, PRICE);
+            given(reservationFeignClient.getReservation(RESERVATION_ID)).willReturn(reservationResponse);
             given(paymentRepository.existsActivePayment(RESERVATION_ID)).willReturn(true);
 
             assertThatThrownBy(() -> paymentService.createPayment(command))


### PR DESCRIPTION
### 📎 관련 이슈
- closes #14 #22 

### 📌 작업 내용
   - Reservation 서비스와 Feign Client로 연동하여 결제 생성 시 totalPrice 및 userId를 예약 정보에서 조회하도록 변경                                          
   - TossPaymentClient 직접 의존을 제거하고 TossPaymentProvider 인터페이스로 추상화 (의존성 역전)
   - 결제 API에 JWT 기반 사용자 인증 적용 및 역할(ADMIN / INTERNAL) 별 접근 제어 추가
   - userId 기반 결제 조회 필터링 추가 (본인 결제만 조회 가능)


### ✨ 변경 사항
   **Feign / Provider**
   - `ReservationFeignClient` — reservation-service 내부 API 호출
   - `ReservationProvider` (domain interface) + `ReservationProviderImpl` — 도메인 레이어가 Feign에 직접 의존하지 않도록 추상화
   - `TossPaymentProvider` (domain interface) + `TossPaymentProviderImpl` — 동일 목적으로 Toss 클라이언트 추상화

   **인증 적용**
   - `PaymentSecurityConfig` — LoginFilter 등록, 전 엔드포인트 인증 필수로 변경
   - `PaymentController` — SecurityUtil로 userId 추출, Admin 엔드포인트에 `@PreAuthorize("hasRole('ADMIN')")` 적용
   - `PaymentInternalController` — `@PreAuthorize("hasRole('INTERNAL')")` 적용
   - `CreatePaymentRequestDto`, `PaymentSuccessRequestDto`, `ConfirmPaymentCommand` — userId를 요청 바디 대신 SecurityContext에서 주입

   **userId 기반 조회 필터링**
   - `JpaPaymentRepository`, `PaymentRepository`, `PaymentRepositoryImpl` — `findByIdAndUserId`, `findByReservationIdAndUserId`,
   `findSuccessPaymentByReservationIdAndUserId` 추가
   - `PaymentService` — `getMyPayment`, `getMyPaymentsByReservationId`, `getMySuccessPaymentByReservationId`를 userId 포함 조회로 변경



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User-scoped payment APIs and new admin endpoints for listing, confirming, and refunding payments
  * Reservation lookup integration and provider-based payment integration (including a mock provider for load tests)
  * Enhanced testing for reservation-validated payment flows

* **Improvements**
  * Stricter authentication and method-level security
  * Provider abstraction for payment and recovery with improved refund/retry logic
  * Updated admin/customer test UI and client-side flows

* **Chores**
  * Added .env to ignore list

<!-- end of auto-generated comment: release notes by coderabbit.ai -->