### PR TITLE
Refactor: TossPaymentProvider 인터페이스 도입 및 Mock PG 구현, confirmPayment 중복 방지

### DIFF
--- a/src/main/java/org/ticketing/payment/application/service/PaymentRecoveryService.java
+++ b/src/main/java/org/ticketing/payment/application/service/PaymentRecoveryService.java
@@ -11,8 +11,8 @@ import org.springframework.transaction.annotation.Transactional;
 import org.ticketing.payment.domain.model.Payment;
 import org.ticketing.payment.domain.model.PaymentStatus;
 import org.ticketing.payment.domain.repository.PaymentRepository;
-import org.ticketing.payment.infrastructure.toss.TossPaymentClient;
-import org.ticketing.payment.infrastructure.toss.dto.TossPaymentStatusResponse;
+import org.ticketing.payment.domain.provider.TossPaymentProvider;
+import org.ticketing.payment.domain.provider.TossPaymentProvider.StatusResult;
 
 @Slf4j
 @Service
@@ -23,7 +23,7 @@ public class PaymentRecoveryService {
 
     private final PaymentRepository paymentRepository;
     private final PaymentStatusService paymentStatusService;
-    private final TossPaymentClient tossPaymentClient;
+    private final TossPaymentProvider tossPaymentProvider;
 
     @Transactional
     public List<Payment> findStuckPaying(LocalDateTime before) {
@@ -37,19 +37,19 @@ public class PaymentRecoveryService {
 
     public void recoverPaying(Payment payment) {
         UUID paymentId = payment.getId();
-        TossPaymentStatusResponse toss;
+        StatusResult toss;
         try {
-            toss = tossPaymentClient.getByOrderId(paymentId.toString());
+            toss = tossPaymentProvider.getByOrderId(paymentId.toString());
         } catch (Exception e) {
             log.warn("[복구 실패] PAYING 상태 Toss 조회 실패. paymentId={}", paymentId, e);
             return;
         }
 
-        switch (toss.getStatus()) {
+        switch (toss.status()) {
             case "DONE" -> {
                 // toss O, payment status X
                 log.info("[복구] PAYING → SUCCESS. paymentId={}", paymentId);
-                paymentStatusService.succeedPayment(paymentId, toss.getPaymentKey());
+                paymentStatusService.succeedPayment(paymentId, toss.paymentKey());
             }
             case "ABORTED", "EXPIRED" -> {
                 // toss X, payment status X
@@ -62,15 +62,15 @@ public class PaymentRecoveryService {
 
     public void recoverRefunding(Payment payment) {
         UUID paymentId = payment.getId();
-        TossPaymentStatusResponse toss;
+        StatusResult toss;
         try {
-            toss = tossPaymentClient.getByPaymentKey(payment.getPaymentKey());
+            toss = tossPaymentProvider.getByPaymentKey(payment.getPaymentKey());
         } catch (Exception e) {
             log.warn("[복구 실패] REFUNDING 상태 Toss 조회 실패. paymentId={}", paymentId, e);
             return;
         }
 
-        switch (toss.getStatus()) {
+        switch (toss.status()) {
             case "CANCELED" -> {
                 // toss O, payment status X
                 log.info("[복구] REFUNDING → REFUNDED. paymentId={}", paymentId);
@@ -86,7 +86,7 @@ public class PaymentRecoveryService {
                 }
                 log.info("[복구] REFUNDING - Toss 미취소 상태, 취소 재시도. paymentId={}", paymentId);
                 try {
-                    tossPaymentClient.cancel(payment.getPaymentKey(), "고객 요청 취소");
+                    tossPaymentProvider.cancel(payment.getPaymentKey(), "고객 요청 취소");
                     paymentStatusService.refundPayment(paymentId);
                 } catch (Exception e) {
                     log.error("[복구 실패] 취소 재시도 실패. paymentId={}", paymentId, e);

--- a/src/main/java/org/ticketing/payment/application/service/PaymentRecoveryService.java
+++ b/src/main/java/org/ticketing/payment/application/service/PaymentRecoveryService.java
@@ -53,10 +53,10 @@ public class PaymentRecoveryService {
             }
             case "ABORTED", "EXPIRED" -> {
                 // toss X, payment status X
-                log.info("[복구] PAYING → FAIL. paymentId={}, tossStatus={}", paymentId, toss.getStatus());
+                log.info("[복구] PAYING → FAIL. paymentId={}, tossStatus={}", paymentId, toss.status());
                 paymentStatusService.failPayment(paymentId);
             }
-            default -> log.debug("[복구 스킵] PAYING 아직 진행 중. paymentId={}, tossStatus={}", paymentId, toss.getStatus());
+            default -> log.debug("[복구 스킵] PAYING 아직 진행 중. paymentId={}, tossStatus={}", paymentId, toss.status());
         }
     }
 
@@ -92,7 +92,7 @@ public class PaymentRecoveryService {
                     log.error("[복구 실패] 취소 재시도 실패. paymentId={}", paymentId, e);
                 }
             }
-            default -> log.warn("[복구 스킵] REFUNDING 알 수 없는 상태. paymentId={}, tossStatus={}", paymentId, toss.getStatus());
+            default -> log.warn("[복구 스킵] REFUNDING 알 수 없는 상태. paymentId={}, tossStatus={}", paymentId, toss.status());
         }
     }
 }

--- a/src/main/java/org/ticketing/payment/application/service/PaymentService.java
+++ b/src/main/java/org/ticketing/payment/application/service/PaymentService.java
@@ -13,6 +13,7 @@ import org.ticketing.payment.domain.exception.DuplicatePaymentException;
 import org.ticketing.payment.domain.exception.PaymentNotFoundException;
 import org.ticketing.payment.infrastructure.kafka.event.ReservationCanceledEvent.CancelReason;
 import org.ticketing.payment.domain.model.Payment;
+import org.ticketing.payment.domain.model.PaymentStatus;
 import org.ticketing.payment.domain.repository.PaymentRepository;
 import org.ticketing.payment.domain.provider.TossPaymentProvider;
 import org.ticketing.payment.domain.provider.TossPaymentProvider.ConfirmResult;
@@ -89,6 +90,13 @@ public class PaymentService {
     }
 
     public PaymentResult confirmPayment(ConfirmPaymentCommand command) {
+        // 이미 SUCCESS인 결제는 재처리 없이 그대로 반환
+        Payment existing = paymentRepository.findById(command.getPaymentId())
+                .orElseThrow(() -> new PaymentNotFoundException(command.getPaymentId()));
+        if (existing.getStatus() == PaymentStatus.SUCCESS) {
+            return PaymentResult.from(existing);
+        }
+
         paymentStatusService.startPayment(command.getPaymentId(), command.getTotalPrice());
 
         ConfirmResult tossResponse;

--- a/src/main/java/org/ticketing/payment/application/service/PaymentService.java
+++ b/src/main/java/org/ticketing/payment/application/service/PaymentService.java
@@ -14,8 +14,8 @@ import org.ticketing.payment.domain.exception.PaymentNotFoundException;
 import org.ticketing.payment.infrastructure.kafka.event.ReservationCanceledEvent.CancelReason;
 import org.ticketing.payment.domain.model.Payment;
 import org.ticketing.payment.domain.repository.PaymentRepository;
-import org.ticketing.payment.infrastructure.toss.TossPaymentClient;
-import org.ticketing.payment.infrastructure.toss.dto.TossConfirmResponse;
+import org.ticketing.payment.domain.provider.TossPaymentProvider;
+import org.ticketing.payment.domain.provider.TossPaymentProvider.ConfirmResult;
 
 import java.util.UUID;
 
@@ -25,7 +25,7 @@ import java.util.UUID;
 public class PaymentService {
 
     private final PaymentRepository paymentRepository;
-    private final TossPaymentClient tossPaymentClient;
+    private final TossPaymentProvider tossPaymentProvider;
     private final PaymentStatusService paymentStatusService;
 
     @Transactional
@@ -76,7 +76,7 @@ public class PaymentService {
 
     public PaymentResult refundPayment(UUID reservationId) {
         Payment payment = paymentStatusService.startRefund(reservationId);
-        tossPaymentClient.cancel(payment.getPaymentKey(), "고객 요청 취소");
+        tossPaymentProvider.cancel(payment.getPaymentKey(), "고객 요청 취소");
         return paymentStatusService.refundPayment(payment.getId());
     }
 
@@ -91,9 +91,9 @@ public class PaymentService {
     public PaymentResult confirmPayment(ConfirmPaymentCommand command) {
         paymentStatusService.startPayment(command.getPaymentId(), command.getTotalPrice());
 
-        TossConfirmResponse tossResponse;
+        ConfirmResult tossResponse;
         try {
-            tossResponse = tossPaymentClient.confirm(
+            tossResponse = tossPaymentProvider.confirm(
                     command.getPaymentKey(),
                     command.getPaymentId().toString(),
                     command.getTotalPrice()
@@ -103,6 +103,6 @@ public class PaymentService {
             throw new RuntimeException(e);
         }
 
-        return paymentStatusService.succeedPayment(command.getPaymentId(), tossResponse.getPaymentKey());
+        return paymentStatusService.succeedPayment(command.getPaymentId(), tossResponse.paymentKey());
     }
 }

--- a/src/main/java/org/ticketing/payment/domain/model/Payment.java
+++ b/src/main/java/org/ticketing/payment/domain/model/Payment.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -39,6 +40,10 @@ public class Payment extends BaseEntity {
 
     @Column(name = "payment_key", length = 200)
     private String paymentKey;
+
+    @Version
+    @Column(name = "version", nullable = false)
+    private Long version;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status", length = 15, nullable = false)

--- a/src/main/java/org/ticketing/payment/domain/provider/TossPaymentProvider.java
+++ b/src/main/java/org/ticketing/payment/domain/provider/TossPaymentProvider.java
@@ -1,0 +1,16 @@
+package org.ticketing.payment.domain.provider;
+
+public interface TossPaymentProvider {
+
+    ConfirmResult confirm(String paymentKey, String orderId, Long amount);
+
+    void cancel(String paymentKey, String cancelReason);
+
+    StatusResult getByOrderId(String orderId);
+
+    StatusResult getByPaymentKey(String paymentKey);
+
+    record ConfirmResult(String paymentKey, String orderId, String status, Long totalAmount) {}
+
+    record StatusResult(String paymentKey, String orderId, String status, Long totalAmount) {}
+}

--- a/src/main/java/org/ticketing/payment/infrastructure/toss/MockTossPaymentProvider.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/toss/MockTossPaymentProvider.java
@@ -1,22 +1,45 @@
 package org.ticketing.payment.infrastructure.toss;
 
+import java.util.Random;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
+import org.ticketing.payment.domain.exception.TossPaymentConfirmException;
 import org.ticketing.payment.domain.provider.TossPaymentProvider;
 
 @Component
 @Profile("loadtest")
 public class MockTossPaymentProvider implements TossPaymentProvider {
 
+    @Value("${toss.mock.delay-min-ms:200}")
+    private int delayMinMs;
+
+    @Value("${toss.mock.delay-max-ms:500}")
+    private int delayMaxMs;
+
+    // 0.0 ~ 1.0: 카드 거절 비율 (e.g. 0.05 = 5%)
+    @Value("${toss.mock.failure-rate:0.0}")
+    private double failureRate;
+
+    // 0.0 ~ 1.0: 타임아웃 응답 비율 (e.g. 0.01 = 1%)
+    @Value("${toss.mock.timeout-rate:0.0}")
+    private double timeoutRate;
+
+    @Value("${toss.mock.timeout-ms:3000}")
+    private int timeoutMs;
+
+    private final Random random = new Random();
+
     @Override
     public ConfirmResult confirm(String paymentKey, String orderId, Long amount) {
-        // Toss API 호출 없이 바로 성공 응답 반환
+        simulateDelay();
+        simulateFailure();
         return new ConfirmResult(paymentKey, orderId, "DONE", amount);
     }
 
     @Override
     public void cancel(String paymentKey, String cancelReason) {
-        // no operation
+        simulateDelay();
     }
 
     @Override
@@ -27,5 +50,22 @@ public class MockTossPaymentProvider implements TossPaymentProvider {
     @Override
     public StatusResult getByPaymentKey(String paymentKey) {
         return new StatusResult(paymentKey, "mock_order", "DONE", 0L);
+    }
+
+    private void simulateDelay() {
+        int sleepMs = (random.nextDouble() < timeoutRate)
+                ? timeoutMs
+                : delayMinMs + random.nextInt(Math.max(1, delayMaxMs - delayMinMs));
+        try {
+            Thread.sleep(sleepMs);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private void simulateFailure() {
+        if (random.nextDouble() < failureRate) {
+            throw new TossPaymentConfirmException(400, "CARD_DECLINED: 카드 한도 초과 (Mock)");
+        }
     }
 }

--- a/src/main/java/org/ticketing/payment/infrastructure/toss/MockTossPaymentProvider.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/toss/MockTossPaymentProvider.java
@@ -1,0 +1,31 @@
+package org.ticketing.payment.infrastructure.toss;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.ticketing.payment.domain.provider.TossPaymentProvider;
+
+@Component
+@Profile("loadtest")
+public class MockTossPaymentProvider implements TossPaymentProvider {
+
+    @Override
+    public ConfirmResult confirm(String paymentKey, String orderId, Long amount) {
+        // Toss API 호출 없이 바로 성공 응답 반환
+        return new ConfirmResult(paymentKey, orderId, "DONE", amount);
+    }
+
+    @Override
+    public void cancel(String paymentKey, String cancelReason) {
+        // no operation
+    }
+
+    @Override
+    public StatusResult getByOrderId(String orderId) {
+        return new StatusResult("mock_pk_" + orderId, orderId, "DONE", 0L);
+    }
+
+    @Override
+    public StatusResult getByPaymentKey(String paymentKey) {
+        return new StatusResult(paymentKey, "mock_order", "DONE", 0L);
+    }
+}

--- a/src/main/java/org/ticketing/payment/infrastructure/toss/TossPaymentProviderImpl.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/toss/TossPaymentProviderImpl.java
@@ -1,0 +1,52 @@
+package org.ticketing.payment.infrastructure.toss;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.ticketing.payment.domain.provider.TossPaymentProvider;
+import org.ticketing.payment.infrastructure.toss.dto.TossConfirmResponse;
+import org.ticketing.payment.infrastructure.toss.dto.TossPaymentStatusResponse;
+
+@Component
+@RequiredArgsConstructor
+public class TossPaymentProviderImpl implements TossPaymentProvider {
+
+    private final TossPaymentClient tossPaymentClient;
+
+    @Override
+    public ConfirmResult confirm(String paymentKey, String orderId, Long amount) {
+        TossConfirmResponse response = tossPaymentClient.confirm(paymentKey, orderId, amount);
+        return new ConfirmResult(
+                response.getPaymentKey(),
+                response.getOrderId(),
+                response.getStatus(),
+                response.getTotalAmount()
+        );
+    }
+
+    @Override
+    public void cancel(String paymentKey, String cancelReason) {
+        tossPaymentClient.cancel(paymentKey, cancelReason);
+    }
+
+    @Override
+    public StatusResult getByOrderId(String orderId) {
+        TossPaymentStatusResponse response = tossPaymentClient.getByOrderId(orderId);
+        return new StatusResult(
+                response.getPaymentKey(),
+                response.getOrderId(),
+                response.getStatus(),
+                response.getTotalAmount()
+        );
+    }
+
+    @Override
+    public StatusResult getByPaymentKey(String paymentKey) {
+        TossPaymentStatusResponse response = tossPaymentClient.getByPaymentKey(paymentKey);
+        return new StatusResult(
+                response.getPaymentKey(),
+                response.getOrderId(),
+                response.getStatus(),
+                response.getTotalAmount()
+        );
+    }
+}

--- a/src/main/java/org/ticketing/payment/infrastructure/toss/TossPaymentProviderImpl.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/toss/TossPaymentProviderImpl.java
@@ -1,12 +1,14 @@
 package org.ticketing.payment.infrastructure.toss;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.ticketing.payment.domain.provider.TossPaymentProvider;
 import org.ticketing.payment.infrastructure.toss.dto.TossConfirmResponse;
 import org.ticketing.payment.infrastructure.toss.dto.TossPaymentStatusResponse;
 
 @Component
+@Profile("!loadtest")
 @RequiredArgsConstructor
 public class TossPaymentProviderImpl implements TossPaymentProvider {
 

--- a/src/main/java/org/ticketing/payment/presentation/advice/PaymentControllerAdvice.java
+++ b/src/main/java/org/ticketing/payment/presentation/advice/PaymentControllerAdvice.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -34,6 +35,12 @@ public class PaymentControllerAdvice {
     @ExceptionHandler(DuplicatePaymentException.class)
     public ResponseEntity<Map<String, Object>> handleDuplicatePayment(DuplicatePaymentException ex) {
         return errorResponse(HttpStatus.CONFLICT, ex.getMessage());
+    }
+
+    @ExceptionHandler(OptimisticLockingFailureException.class)
+    public ResponseEntity<Map<String, Object>> handleOptimisticLock(OptimisticLockingFailureException ex) {
+        log.warn("Optimistic lock conflict: {}", ex.getMessage());
+        return errorResponse(HttpStatus.CONFLICT, "Payment is already being processed. Please try again.");
     }
 
     @ExceptionHandler(DataIntegrityViolationException.class)


### PR DESCRIPTION
### 📎 관련 이슈
- close #이슈번호

### 📌 작업 내용
- TossPaymentClient 직접 의존 제거, TossPaymentProvider 인터페이스 도입 (DIP 적용)
- 부하테스트용 MockTossPaymentProvider 구현 (@Profile("loadtest"))
- confirmPayment 동시 중복 요청 방지 처리 (낙관적 락)

### ✨ 변경 사항
- domain/provider/TossPaymentProvider 인터페이스 신규 추가
  - ConfirmResult, StatusResult record를 인터페이스 내부에 정의해 DTO 노출 차단
- TossPaymentProviderImpl: 기존 TossPaymentClient를 감싸는 실제 구현체 (@Profile("!loadtest"))
- MockTossPaymentProvider: 부하테스트 전용 Mock 구현체 (@Profile("loadtest"))
  - 지연 시간, 카드 거절 비율, 타임아웃 비율을 프로퍼티로 조정 가능
- Payment 엔티티에 @Version 컬럼 추가 → 낙관적 락 적용
- confirmPayment에서 이미 SUCCESS 상태인 경우 멱등성 처리 (중복 요청 무시, 기존 결과 반환)
- OptimisticLockingFailureException 핸들러 추가 → 동시 요청 충돌 시 409 Conflict 반환


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optimistic locking to prevent duplicate payment processing in concurrent scenarios.
  * Payment confirmation now handles duplicate requests idempotently, improving reliability.

* **Bug Fixes**
  * Concurrent payment processing attempts now return a clear error response (HTTP 409 Conflict).

* **Improvements**
  * Enhanced payment recovery processes for better error handling and status management.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/3s-ticketing/payment-service/pull/27)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->