### PR TITLE
Feat: gateway to payment auth 처리

### DIFF
--- a/src/main/java/org/ticketing/payment/application/service/PaymentService.java
+++ b/src/main/java/org/ticketing/payment/application/service/PaymentService.java
@@ -54,6 +54,13 @@ public class PaymentService {
     }
 
     @Transactional(readOnly = true)
+    public PaymentResult getMyPayment(UUID userId, UUID paymentId) {
+        Payment payment = paymentRepository.findByIdAndUserId(paymentId, userId)
+                .orElseThrow(() -> new PaymentNotFoundException(paymentId));
+        return PaymentResult.from(payment);
+    }
+
+    @Transactional(readOnly = true)
     public Page<PaymentResult> getPayments(Pageable pageable) {
         return paymentRepository.findAll(pageable).map(PaymentResult::from);
     }
@@ -64,8 +71,20 @@ public class PaymentService {
     }
 
     @Transactional(readOnly = true)
+    public Page<PaymentResult> getMyPaymentsByReservationId(UUID userId, UUID reservationId, Pageable pageable) {
+        return paymentRepository.findByReservationIdAndUserId(reservationId, userId, pageable).map(PaymentResult::from);
+    }
+
+    @Transactional(readOnly = true)
     public PaymentResult getSuccessPaymentByReservationId(UUID reservationId) {
         Payment payment = paymentRepository.findSuccessPaymentByReservationId(reservationId)
+                .orElseThrow(() -> new PaymentNotFoundException(reservationId));
+        return PaymentResult.from(payment);
+    }
+
+    @Transactional(readOnly = true)
+    public PaymentResult getMySuccessPaymentByReservationId(UUID userId, UUID reservationId) {
+        Payment payment = paymentRepository.findSuccessPaymentByReservationIdAndUserId(reservationId, userId)
                 .orElseThrow(() -> new PaymentNotFoundException(reservationId));
         return PaymentResult.from(payment);
     }

--- a/src/main/java/org/ticketing/payment/domain/repository/PaymentRepository.java
+++ b/src/main/java/org/ticketing/payment/domain/repository/PaymentRepository.java
@@ -12,10 +12,13 @@ import org.ticketing.payment.domain.model.PaymentStatus;
 public interface PaymentRepository {
     Payment save(Payment payment);
     Optional<Payment> findById(UUID id);
+    Optional<Payment> findByIdAndUserId(UUID id, UUID userId);
     Page<Payment> findAll(Pageable pageable);
     boolean existsActivePayment(UUID reservationId);
     Page<Payment> findByReservationId(UUID reservationId, Pageable pageable);
+    Page<Payment> findByReservationIdAndUserId(UUID reservationId, UUID userId, Pageable pageable);
     Optional<Payment> findSuccessPaymentByReservationId(UUID reservationId);
+    Optional<Payment> findSuccessPaymentByReservationIdAndUserId(UUID reservationId, UUID userId);
     Page<Payment> findByUserId(UUID userId, Pageable pageable);
     List<Payment> findStuckPayments(PaymentStatus status, LocalDateTime before);
 }

--- a/src/main/java/org/ticketing/payment/infrastructure/persistence/JpaPaymentRepository.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/persistence/JpaPaymentRepository.java
@@ -12,10 +12,13 @@ import org.ticketing.payment.domain.model.PaymentStatus;
 
 public interface JpaPaymentRepository extends JpaRepository<Payment, UUID> {
     Optional<Payment> findByIdAndDeletedAtIsNull(UUID id);
+    Optional<Payment> findByIdAndUserIdAndDeletedAtIsNull(UUID id, UUID userId);
     Page<Payment> findAllByDeletedAtIsNull(Pageable pageable);
     boolean existsByReservationIdAndStatusIn(UUID reservationId, List<PaymentStatus> statuses);
     Page<Payment> findByReservationIdAndDeletedAtIsNull(UUID reservationId, Pageable pageable);
+    Page<Payment> findByReservationIdAndUserIdAndDeletedAtIsNull(UUID reservationId, UUID userId, Pageable pageable);
     Optional<Payment> findFirstByReservationIdAndStatusAndDeletedAtIsNullOrderByCreatedAtDesc(UUID reservationId, PaymentStatus status);
+    Optional<Payment> findFirstByReservationIdAndUserIdAndStatusAndDeletedAtIsNullOrderByCreatedAtDesc(UUID reservationId, UUID userId, PaymentStatus status);
     Page<Payment> findByUserIdAndDeletedAtIsNull(UUID userId, Pageable pageable);
     List<Payment> findByStatusAndModifiedAtBeforeAndDeletedAtIsNull(PaymentStatus status, LocalDateTime before);
 }

--- a/src/main/java/org/ticketing/payment/infrastructure/persistence/PaymentRepositoryImpl.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/persistence/PaymentRepositoryImpl.java
@@ -28,6 +28,11 @@ public class PaymentRepositoryImpl implements PaymentRepository {
     }
 
     @Override
+    public Optional<Payment> findByIdAndUserId(UUID id, UUID userId) {
+        return jpaPaymentRepository.findByIdAndUserIdAndDeletedAtIsNull(id, userId);
+    }
+
+    @Override
     public Page<Payment> findAll(Pageable pageable) {
         return jpaPaymentRepository.findAllByDeletedAtIsNull(pageable);
     }
@@ -44,8 +49,18 @@ public class PaymentRepositoryImpl implements PaymentRepository {
     }
 
     @Override
+    public Page<Payment> findByReservationIdAndUserId(UUID reservationId, UUID userId, Pageable pageable) {
+        return jpaPaymentRepository.findByReservationIdAndUserIdAndDeletedAtIsNull(reservationId, userId, pageable);
+    }
+
+    @Override
     public Optional<Payment> findSuccessPaymentByReservationId(UUID reservationId) {
         return jpaPaymentRepository.findFirstByReservationIdAndStatusAndDeletedAtIsNullOrderByCreatedAtDesc(reservationId, PaymentStatus.SUCCESS);
+    }
+
+    @Override
+    public Optional<Payment> findSuccessPaymentByReservationIdAndUserId(UUID reservationId, UUID userId) {
+        return jpaPaymentRepository.findFirstByReservationIdAndUserIdAndStatusAndDeletedAtIsNullOrderByCreatedAtDesc(reservationId, userId, PaymentStatus.SUCCESS);
     }
 
     @Override

--- a/src/main/java/org/ticketing/payment/presentation/controller/PaymentController.java
+++ b/src/main/java/org/ticketing/payment/presentation/controller/PaymentController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.ticketing.payment.application.service.PaymentService;
@@ -29,28 +30,35 @@ public class PaymentController {
     // 결제 시도 생성 [Customer]
     // (사용자가 결제 요청 버튼 누를 때)
     @PostMapping
-    public PaymentResponseDto createPayment(@RequestBody @Valid CreatePaymentRequestDto request) {
-        return PaymentResponseDto.from(paymentService.createPayment(request.toCommand()));
+    public PaymentResponseDto createPayment(
+            @RequestHeader("X-User-Id") UUID userId,
+            @RequestBody @Valid CreatePaymentRequestDto request) {
+        return PaymentResponseDto.from(paymentService.createPayment(request.toCommand(userId)));
     }
 
     // paymentId에 따른 결제 정보 조회 [Customer]
     @GetMapping("/my/{paymentId}")
-    public PaymentResponseDto getMyPayment(@PathVariable @NotNull UUID paymentId) {
-        return PaymentResponseDto.from(paymentService.getPayment(paymentId));
+    public PaymentResponseDto getMyPayment(
+            @RequestHeader("X-User-Id") UUID userId,
+            @PathVariable @NotNull UUID paymentId) {
+        return PaymentResponseDto.from(paymentService.getMyPayment(userId, paymentId));
     }
 
     // reservationId에 따른 결제 정보 조회 [Customer]
     @GetMapping("/my/reservations/{reservationId}")
     public Page<PaymentResponseDto> getMyPaymentsByReservationId(
+            @RequestHeader("X-User-Id") UUID userId,
             @PathVariable @NotNull UUID reservationId,
             @PageableDefault(size = 10, sort = "createdAt") Pageable pageable) {
-        return paymentService.getPaymentsByReservationId(reservationId, pageable).map(PaymentResponseDto::from);
+        return paymentService.getMyPaymentsByReservationId(userId, reservationId, pageable).map(PaymentResponseDto::from);
     }
 
     // reservationId에 따른 성공 결제 정보 조회 [Customer]
     @GetMapping("/my/reservations/{reservationId}/success")
-    public PaymentResponseDto getMySuccessPaymentByReservationId(@PathVariable @NotNull UUID reservationId) {
-        return PaymentResponseDto.from(paymentService.getSuccessPaymentByReservationId(reservationId));
+    public PaymentResponseDto getMySuccessPaymentByReservationId(
+            @RequestHeader("X-User-Id") UUID userId,
+            @PathVariable @NotNull UUID reservationId) {
+        return PaymentResponseDto.from(paymentService.getMySuccessPaymentByReservationId(userId, reservationId));
     }
 
     // paymentId에 따른 결제 정보 조회 [Admin]

--- a/src/main/java/org/ticketing/payment/presentation/dto/request/CreatePaymentRequestDto.java
+++ b/src/main/java/org/ticketing/payment/presentation/dto/request/CreatePaymentRequestDto.java
@@ -14,16 +14,13 @@ import org.ticketing.payment.application.dto.command.CreatePaymentCommand;
 public class CreatePaymentRequestDto {
 
     @NotNull
-    private UUID userId;
-
-    @NotNull
     private UUID reservationId;
 
     @NotNull
     @Positive
     private Long totalPrice;
 
-    public CreatePaymentCommand toCommand() {
+    public CreatePaymentCommand toCommand(UUID userId) {
         return new CreatePaymentCommand(userId, reservationId, totalPrice);
     }
 }


### PR DESCRIPTION
### 📎 관련 이슈
- close #22 

 ### 📌 작업 내용
  게이트웨이가 JWT의 `sub` 클레임을 추출해 `X-User-Id` 헤더로 주입하는 구조에 맞게, 결제 API에서 userId를 요청 바디 대신 헤더로 받도록 수정하고,`/my` 엔드포인트에 userId 기반 데이터 격리를 적용했습니다.

  ### ✨ 변경 사항
  - `CreatePaymentRequestDto`에서 `userId` 필드 제거 → `@RequestHeader("X-User-Id")`로 수신
  - `POST /api/payments` — 헤더에서 userId를 받아 결제 생성 시 사용
  - `GET /api/payments/my/{paymentId}` — userId + paymentId 조합으로 본인 결제만 조회
  - `GET /api/payments/my/reservations/{reservationId}` — userId 기반 필터링 적용
  - `GET /api/payments/my/reservations/{reservationId}/success` — userId 기반 필터링 적용
  - 위 My 엔드포인트 전용 서비스 메서드(`getMyPayment`, `getMyPaymentsByReservationId`, `getMySuccessPaymentByReservationId`) 및 Repository 메서드 추가
-> `/my` 엔드포인트는 DB 쿼리 레벨에서 `userId AND paymentId(or reservationId)` 조건으로 필터링하므로, 다른 유저의 결제 ID를 직접 입력해도 조회되지 않습니다.
  ### 📝 리뷰 포인트 
  -  역할 기반 인가는 미적용 상태입니다. 

  ### 🧠 기타 참고 사항
  - 게이트웨이의 `UserIdInjectionFilter`가 인증된 요청에 한해 `X-User-Id`를 주입하며, 클라이언트가 임의로 헤더를 설정하더라도 게이트웨이에서 덮어씁니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added user-scoped payment retrieval endpoints to ensure users can only access their own payments.

* **Bug Fixes**
  * User identification now sourced from request header instead of request body for improved security.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/3s-ticketing/payment-service/pull/28)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->