### PR TITLE
Feat: reservation detail 조회 feign 추가 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,11 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    runtimeOnly 'org.springframework.boot:spring-boot-starter-actuator'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+    implementation 'io.micrometer:micrometer-tracing-bridge-brave'
+    runtimeOnly 'io.zipkin.reporter2:zipkin-reporter-brave'
+
     runtimeOnly 'org.postgresql:postgresql'
 
     compileOnly 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,8 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     implementation 'org.springframework.kafka:spring-kafka'
+
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/ticketing/payment/PaymentApplication.java
+++ b/src/main/java/org/ticketing/payment/PaymentApplication.java
@@ -2,7 +2,9 @@ package org.ticketing.payment;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
+@EnableFeignClients
 @SpringBootApplication
 public class PaymentApplication {
 

--- a/src/main/java/org/ticketing/payment/application/dto/command/CreatePaymentCommand.java
+++ b/src/main/java/org/ticketing/payment/application/dto/command/CreatePaymentCommand.java
@@ -10,5 +10,4 @@ public class CreatePaymentCommand {
 
     private UUID userId;
     private UUID reservationId;
-    private Long totalPrice;
 }

--- a/src/main/java/org/ticketing/payment/application/service/PaymentService.java
+++ b/src/main/java/org/ticketing/payment/application/service/PaymentService.java
@@ -10,7 +10,10 @@ import org.ticketing.payment.application.dto.command.CreatePaymentCommand;
 import org.ticketing.payment.application.dto.result.PaymentResult;
 import lombok.extern.slf4j.Slf4j;
 import org.ticketing.payment.domain.exception.DuplicatePaymentException;
+import org.ticketing.payment.domain.exception.InvalidReservationStateException;
 import org.ticketing.payment.domain.exception.PaymentNotFoundException;
+import org.ticketing.payment.domain.exception.PaymentUserMismatchException;
+import org.ticketing.payment.domain.client.ReservationClient;
 import org.ticketing.payment.infrastructure.kafka.event.ReservationCanceledEvent.CancelReason;
 import org.ticketing.payment.domain.model.Payment;
 import org.ticketing.payment.domain.model.PaymentStatus;
@@ -28,20 +31,29 @@ public class PaymentService {
     private final PaymentRepository paymentRepository;
     private final TossPaymentProvider tossPaymentProvider;
     private final PaymentStatusService paymentStatusService;
+    private final ReservationClient reservationClient;
 
     @Transactional
     public PaymentResult createPayment(CreatePaymentCommand command) {
 
-        // Todo: [Feign] Reservation reservationId에 대한 reservation 정보 대조 (totalPrice, userId)
-        // Todo: [Feign] Reservation 해당 예약 상태가 PENDING인지 & 좌석 상태가 HOLD인지 확인
+        ReservationClient.ReservationDetail reservation =
+                reservationClient.getReservationDetail(command.getReservationId());
+
+        if (!reservation.isValid()) {
+            throw new InvalidReservationStateException(command.getReservationId());
+        }
+        if (!reservation.userId().equals(command.getUserId())) {
+            throw new PaymentUserMismatchException(reservation.userId(), command.getUserId());
+        }
 
         if (paymentRepository.existsActivePayment(command.getReservationId())) {
             throw new DuplicatePaymentException(command.getReservationId());
         }
+
         Payment payment = Payment.create(
                 command.getUserId(),
                 command.getReservationId(),
-                command.getTotalPrice()
+                reservation.totalPrice()
         );
         return PaymentResult.from(paymentRepository.save(payment));
     }

--- a/src/main/java/org/ticketing/payment/domain/client/ReservationClient.java
+++ b/src/main/java/org/ticketing/payment/domain/client/ReservationClient.java
@@ -1,0 +1,10 @@
+package org.ticketing.payment.domain.client;
+
+import java.util.UUID;
+
+public interface ReservationClient {
+
+    ReservationDetail getReservationDetail(UUID reservationId);
+
+    record ReservationDetail(UUID reservationId, UUID userId, Long totalPrice, boolean isValid) {}
+}

--- a/src/main/java/org/ticketing/payment/domain/exception/InvalidReservationStateException.java
+++ b/src/main/java/org/ticketing/payment/domain/exception/InvalidReservationStateException.java
@@ -1,0 +1,10 @@
+package org.ticketing.payment.domain.exception;
+
+import java.util.UUID;
+
+public class InvalidReservationStateException extends RuntimeException {
+
+    public InvalidReservationStateException(UUID reservationId) {
+        super("결제 불가한 예약 상태: reservationId=" + reservationId);
+    }
+}

--- a/src/main/java/org/ticketing/payment/domain/exception/PaymentUserMismatchException.java
+++ b/src/main/java/org/ticketing/payment/domain/exception/PaymentUserMismatchException.java
@@ -1,0 +1,10 @@
+package org.ticketing.payment.domain.exception;
+
+import java.util.UUID;
+
+public class PaymentUserMismatchException extends RuntimeException {
+
+    public PaymentUserMismatchException(UUID expected, UUID actual) {
+        super("사용자 ID 불일치: 예약의 userId=" + expected + ", 요청 userId=" + actual);
+    }
+}

--- a/src/main/java/org/ticketing/payment/infrastructure/feign/ReservationFeignClient.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/feign/ReservationFeignClient.java
@@ -1,0 +1,16 @@
+package org.ticketing.payment.infrastructure.feign;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.ticketing.payment.domain.client.ReservationClient;
+
+import java.util.UUID;
+
+@FeignClient(name = "reservation-service", path = "/internal/reservations")
+public interface ReservationFeignClient extends ReservationClient {
+
+    @GetMapping("/{reservationId}/detail")
+    @Override
+    ReservationDetail getReservationDetail(@PathVariable UUID reservationId);
+}

--- a/src/main/java/org/ticketing/payment/presentation/advice/PaymentControllerAdvice.java
+++ b/src/main/java/org/ticketing/payment/presentation/advice/PaymentControllerAdvice.java
@@ -1,5 +1,6 @@
 package org.ticketing.payment.presentation.advice;
 
+import feign.FeignException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
@@ -11,10 +12,12 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.ticketing.payment.domain.exception.DuplicatePaymentException;
 import org.ticketing.payment.domain.exception.InvalidPaymentStatusTransitionException;
+import org.ticketing.payment.domain.exception.InvalidReservationStateException;
 import org.ticketing.payment.domain.exception.PaymentAlreadyTerminatedException;
 import org.ticketing.payment.domain.exception.PaymentAmountMismatchException;
 import org.ticketing.payment.domain.exception.PaymentNotFoundException;
 import org.ticketing.payment.domain.exception.PaymentReservationMismatchException;
+import org.ticketing.payment.domain.exception.PaymentUserMismatchException;
 import org.ticketing.payment.domain.exception.TossPaymentCancelException;
 import org.ticketing.payment.domain.exception.TossPaymentConfirmException;
 
@@ -71,6 +74,28 @@ public class PaymentControllerAdvice {
     @ExceptionHandler(PaymentReservationMismatchException.class)
     public ResponseEntity<Map<String, Object>> handleReservationMismatch(PaymentReservationMismatchException ex) {
         return errorResponse(HttpStatus.BAD_REQUEST, ex.getMessage());
+    }
+
+    @ExceptionHandler(InvalidReservationStateException.class)
+    public ResponseEntity<Map<String, Object>> handleInvalidReservationState(InvalidReservationStateException ex) {
+        return errorResponse(HttpStatus.CONFLICT, ex.getMessage());
+    }
+
+    @ExceptionHandler(PaymentUserMismatchException.class)
+    public ResponseEntity<Map<String, Object>> handleUserMismatch(PaymentUserMismatchException ex) {
+        return errorResponse(HttpStatus.BAD_REQUEST, ex.getMessage());
+    }
+
+    @ExceptionHandler(FeignException.NotFound.class)
+    public ResponseEntity<Map<String, Object>> handleFeignNotFound(FeignException.NotFound ex) {
+        log.warn("Reservation not found via Feign: {}", ex.getMessage());
+        return errorResponse(HttpStatus.NOT_FOUND, "예약 정보를 찾을 수 없습니다.");
+    }
+
+    @ExceptionHandler(FeignException.class)
+    public ResponseEntity<Map<String, Object>> handleFeignException(FeignException ex) {
+        log.error("Feign call failed: status={}, message={}", ex.status(), ex.getMessage());
+        return errorResponse(HttpStatus.BAD_GATEWAY, "예약 서비스 호출에 실패했습니다.");
     }
 
     @ExceptionHandler(TossPaymentConfirmException.class)

--- a/src/main/java/org/ticketing/payment/presentation/dto/request/CreatePaymentRequestDto.java
+++ b/src/main/java/org/ticketing/payment/presentation/dto/request/CreatePaymentRequestDto.java
@@ -16,11 +16,7 @@ public class CreatePaymentRequestDto {
     @NotNull
     private UUID reservationId;
 
-    @NotNull
-    @Positive
-    private Long totalPrice;
-
     public CreatePaymentCommand toCommand(UUID userId) {
-        return new CreatePaymentCommand(userId, reservationId, totalPrice);
+        return new CreatePaymentCommand(userId, reservationId);
     }
 }


### PR DESCRIPTION
### 📎 관련 이슈
- close #14 

### 📌 작업 내용

   - `reservation-service` Feign 클라이언트 연동으로 결제 생성 시 예약 정보 검증 추가
   - `totalPrice`를 클라이언트 요청값 대신 reservation-service에서 직접 조회하도록 변경
   - `FeignException` 핸들링 추가로 예약 서비스 오류 시 적절한 HTTP 상태 반환


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Integrated with the reservation service to validate reservation details and user information during payment creation.
  * Enhanced error handling with specific responses for invalid reservations and user ID mismatches.
  * Added monitoring and observability capabilities to the payment system.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/3s-ticketing/payment-service/pull/29)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->