### PR TITLE
[Feat] Toss RestClient 빈 분리 및 Resilience4j Circuit Breaker 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,8 @@ dependencies {
     implementation 'org.springframework.kafka:spring-kafka'
 
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+
+    implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/ticketing/payment/application/service/PaymentService.java
+++ b/src/main/java/org/ticketing/payment/application/service/PaymentService.java
@@ -89,6 +89,13 @@ public class PaymentService {
     }
 
     @Transactional(readOnly = true)
+    public PaymentResult getLatestPaymentByReservationId(UUID reservationId) {
+        Payment payment = paymentRepository.findLatestByReservationId(reservationId)
+                .orElseThrow(() -> new PaymentException(PaymentErrorCode.PAYMENT_NOT_FOUND, "reservationId=" + reservationId));
+        return PaymentResult.from(payment);
+    }
+
+    @Transactional(readOnly = true)
     public PaymentResult getSuccessPaymentByReservationId(UUID reservationId) {
         Payment payment = paymentRepository.findSuccessPaymentByReservationId(reservationId)
                 .orElseThrow(() -> new PaymentException(PaymentErrorCode.PAYMENT_NOT_FOUND, "reservationId=" + reservationId));

--- a/src/main/java/org/ticketing/payment/domain/exception/PaymentErrorCode.java
+++ b/src/main/java/org/ticketing/payment/domain/exception/PaymentErrorCode.java
@@ -16,7 +16,8 @@ public enum PaymentErrorCode {
     AMOUNT_MISMATCH(HttpStatus.BAD_REQUEST, "결제 금액 불일치"),
     TOSS_CONFIRM_FAILED(HttpStatus.BAD_GATEWAY, "Toss 결제 승인 실패"),
     TOSS_CANCEL_FAILED(HttpStatus.BAD_GATEWAY, "Toss 결제 취소 실패"),
-    TOSS_STATUS_FETCH_FAILED(HttpStatus.BAD_GATEWAY, "Toss 결제 상태 조회 실패");
+    TOSS_STATUS_FETCH_FAILED(HttpStatus.BAD_GATEWAY, "Toss 결제 상태 조회 실패"),
+    RESERVATION_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "예약 서비스 일시 장애");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/org/ticketing/payment/domain/exception/PaymentErrorCode.java
+++ b/src/main/java/org/ticketing/payment/domain/exception/PaymentErrorCode.java
@@ -15,7 +15,8 @@ public enum PaymentErrorCode {
     ALREADY_TERMINATED(HttpStatus.CONFLICT, "이미 종료된 결제입니다"),
     AMOUNT_MISMATCH(HttpStatus.BAD_REQUEST, "결제 금액 불일치"),
     TOSS_CONFIRM_FAILED(HttpStatus.BAD_GATEWAY, "Toss 결제 승인 실패"),
-    TOSS_CANCEL_FAILED(HttpStatus.BAD_GATEWAY, "Toss 결제 취소 실패");
+    TOSS_CANCEL_FAILED(HttpStatus.BAD_GATEWAY, "Toss 결제 취소 실패"),
+    TOSS_STATUS_FETCH_FAILED(HttpStatus.BAD_GATEWAY, "Toss 결제 상태 조회 실패");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/org/ticketing/payment/domain/repository/PaymentRepository.java
+++ b/src/main/java/org/ticketing/payment/domain/repository/PaymentRepository.java
@@ -21,4 +21,5 @@ public interface PaymentRepository {
     Optional<Payment> findSuccessPaymentByReservationIdAndUserId(UUID reservationId, UUID userId);
     Page<Payment> findByUserId(UUID userId, Pageable pageable);
     List<Payment> findStuckPayments(PaymentStatus status, LocalDateTime before);
+    Optional<Payment> findLatestByReservationId(UUID reservationId);
 }

--- a/src/main/java/org/ticketing/payment/infrastructure/config/TossRestClientConfig.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/config/TossRestClientConfig.java
@@ -1,0 +1,31 @@
+package org.ticketing.payment.infrastructure.config;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Base64;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+import org.ticketing.payment.infrastructure.toss.TossPaymentProperties;
+
+@Configuration
+public class TossRestClientConfig {
+
+    @Bean
+    public RestClient tossRestClient(TossPaymentProperties props) {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(Duration.ofSeconds(3));
+        factory.setReadTimeout(Duration.ofSeconds(10));
+
+        String encoded = Base64.getEncoder()
+                .encodeToString((props.getSecretKey() + ":").getBytes(StandardCharsets.UTF_8));
+
+        return RestClient.builder()
+                .requestFactory(factory)
+                .baseUrl(props.getBaseUrl())
+                .defaultHeader(HttpHeaders.AUTHORIZATION, "Basic " + encoded)
+                .build();
+    }
+}

--- a/src/main/java/org/ticketing/payment/infrastructure/feign/ReservationClientFallback.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/feign/ReservationClientFallback.java
@@ -1,0 +1,17 @@
+package org.ticketing.payment.infrastructure.feign;
+
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+import org.ticketing.payment.domain.client.ReservationClient;
+import org.ticketing.payment.domain.exception.PaymentErrorCode;
+import org.ticketing.payment.domain.exception.PaymentException;
+
+@Component
+public class ReservationClientFallback implements ReservationClient {
+
+    @Override
+    public ReservationDetail getReservationDetail(UUID reservationId) {
+        throw new PaymentException(PaymentErrorCode.RESERVATION_SERVICE_UNAVAILABLE,
+                "reservationId=" + reservationId);
+    }
+}

--- a/src/main/java/org/ticketing/payment/infrastructure/feign/ReservationFeignClient.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/feign/ReservationFeignClient.java
@@ -7,7 +7,7 @@ import org.ticketing.payment.domain.client.ReservationClient;
 
 import java.util.UUID;
 
-@FeignClient(name = "reservation-service", path = "/internal/reservations")
+@FeignClient(name = "reservation-service", path = "/internal/reservations", fallback = ReservationClientFallback.class)
 public interface ReservationFeignClient extends ReservationClient {
 
     @GetMapping("/{reservationId}/detail")

--- a/src/main/java/org/ticketing/payment/infrastructure/persistence/JpaPaymentRepository.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/persistence/JpaPaymentRepository.java
@@ -18,6 +18,7 @@ public interface JpaPaymentRepository extends JpaRepository<Payment, UUID> {
     Page<Payment> findByReservationIdAndDeletedAtIsNull(UUID reservationId, Pageable pageable);
     Page<Payment> findByReservationIdAndUserIdAndDeletedAtIsNull(UUID reservationId, UUID userId, Pageable pageable);
     Optional<Payment> findFirstByReservationIdAndStatusAndDeletedAtIsNullOrderByCreatedAtDesc(UUID reservationId, PaymentStatus status);
+    Optional<Payment> findFirstByReservationIdAndDeletedAtIsNullOrderByCreatedAtDesc(UUID reservationId);
     Optional<Payment> findFirstByReservationIdAndUserIdAndStatusAndDeletedAtIsNullOrderByCreatedAtDesc(UUID reservationId, UUID userId, PaymentStatus status);
     Page<Payment> findByUserIdAndDeletedAtIsNull(UUID userId, Pageable pageable);
     List<Payment> findByStatusAndModifiedAtBeforeAndDeletedAtIsNull(PaymentStatus status, LocalDateTime before);

--- a/src/main/java/org/ticketing/payment/infrastructure/persistence/PaymentRepositoryImpl.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/persistence/PaymentRepositoryImpl.java
@@ -72,4 +72,9 @@ public class PaymentRepositoryImpl implements PaymentRepository {
     public List<Payment> findStuckPayments(PaymentStatus status, LocalDateTime before) {
         return jpaPaymentRepository.findByStatusAndModifiedAtBeforeAndDeletedAtIsNull(status, before);
     }
+
+    @Override
+    public Optional<Payment> findLatestByReservationId(UUID reservationId) {
+        return jpaPaymentRepository.findFirstByReservationIdAndDeletedAtIsNullOrderByCreatedAtDesc(reservationId);
+    }
 }

--- a/src/main/java/org/ticketing/payment/infrastructure/toss/MockTossPaymentProvider.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/toss/MockTossPaymentProvider.java
@@ -1,5 +1,6 @@
 package org.ticketing.payment.infrastructure.toss;
 
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import java.util.Random;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
@@ -32,6 +33,7 @@ public class MockTossPaymentProvider implements TossPaymentProvider {
     private final Random random = new Random();
 
     @Override
+    @CircuitBreaker(name = "toss", fallbackMethod = "confirmFallback")
     public ConfirmResult confirm(String paymentKey, String orderId, Long amount) {
         simulateDelay();
         simulateFailure();
@@ -39,6 +41,7 @@ public class MockTossPaymentProvider implements TossPaymentProvider {
     }
 
     @Override
+    @CircuitBreaker(name = "toss", fallbackMethod = "cancelFallback")
     public void cancel(String paymentKey, String cancelReason) {
         simulateDelay();
     }
@@ -68,5 +71,13 @@ public class MockTossPaymentProvider implements TossPaymentProvider {
         if (random.nextDouble() < failureRate) {
             throw new PaymentException(PaymentErrorCode.TOSS_CONFIRM_FAILED, "status: 400, body: CARD_DECLINED: 카드 한도 초과 (Mock)");
         }
+    }
+
+    private ConfirmResult confirmFallback(String paymentKey, String orderId, Long amount, Throwable t) {
+        throw new PaymentException(PaymentErrorCode.TOSS_CONFIRM_FAILED, "PG 일시 장애 (CB OPEN): " + t.getMessage());
+    }
+
+    private void cancelFallback(String paymentKey, String cancelReason, Throwable t) {
+        throw new PaymentException(PaymentErrorCode.TOSS_CANCEL_FAILED, "PG 일시 장애 (CB OPEN): " + t.getMessage());
     }
 }

--- a/src/main/java/org/ticketing/payment/infrastructure/toss/TossPaymentClient.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/toss/TossPaymentClient.java
@@ -1,7 +1,6 @@
 package org.ticketing.payment.infrastructure.toss;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
@@ -18,18 +17,11 @@ import org.ticketing.payment.infrastructure.toss.dto.TossPaymentStatusResponse;
 @RequiredArgsConstructor
 public class TossPaymentClient {
 
-    private final TossPaymentProperties properties;
+    private final RestClient tossRestClient;
 
     public TossConfirmResponse confirm(String paymentKey, String orderId, Long amount) {
-        String encoded = Base64.getEncoder()
-                .encodeToString((properties.getSecretKey() + ":").getBytes(StandardCharsets.UTF_8));
-
-        return RestClient.builder()
-                .baseUrl(properties.getBaseUrl())
-                .build()
-                .post()
+        return tossRestClient.post()
                 .uri("/v1/payments/confirm")
-                .header("Authorization", "Basic " + encoded)
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(new TossConfirmRequest(paymentKey, orderId, amount))
                 .retrieve()
@@ -45,15 +37,8 @@ public class TossPaymentClient {
     }
 
     public TossCancelResponse cancel(String paymentKey, String cancelReason) {
-        String encoded = Base64.getEncoder()
-                .encodeToString((properties.getSecretKey() + ":").getBytes(StandardCharsets.UTF_8));
-
-        return RestClient.builder()
-                .baseUrl(properties.getBaseUrl())
-                .build()
-                .post()
+        return tossRestClient.post()
                 .uri("/v1/payments/{paymentKey}/cancel", paymentKey)
-                .header("Authorization", "Basic " + encoded)
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(new TossCancelRequest(cancelReason))
                 .retrieve()
@@ -70,29 +55,15 @@ public class TossPaymentClient {
 
     // TOSS에서의 orderId = Payment service의 paymentId
     public TossPaymentStatusResponse getByOrderId(String orderId) {
-        String encoded = Base64.getEncoder()
-                .encodeToString((properties.getSecretKey() + ":").getBytes(StandardCharsets.UTF_8));
-
-        return RestClient.builder()
-                .baseUrl(properties.getBaseUrl())
-                .build()
-                .get()
+        return tossRestClient.get()
                 .uri("/v1/payments/orders/{orderId}", orderId)
-                .header("Authorization", "Basic " + encoded)
                 .retrieve()
                 .body(TossPaymentStatusResponse.class);
     }
 
     public TossPaymentStatusResponse getByPaymentKey(String paymentKey) {
-        String encoded = Base64.getEncoder()
-                .encodeToString((properties.getSecretKey() + ":").getBytes(StandardCharsets.UTF_8));
-
-        return RestClient.builder()
-                .baseUrl(properties.getBaseUrl())
-                .build()
-                .get()
+        return tossRestClient.get()
                 .uri("/v1/payments/{paymentKey}", paymentKey)
-                .header("Authorization", "Basic " + encoded)
                 .retrieve()
                 .body(TossPaymentStatusResponse.class);
     }

--- a/src/main/java/org/ticketing/payment/infrastructure/toss/TossPaymentClient.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/toss/TossPaymentClient.java
@@ -58,6 +58,14 @@ public class TossPaymentClient {
         return tossRestClient.get()
                 .uri("/v1/payments/orders/{orderId}", orderId)
                 .retrieve()
+                .onStatus(
+                        status -> !status.is2xxSuccessful(),
+                        (request, response) -> {
+                            String body = new String(response.getBody().readAllBytes(), StandardCharsets.UTF_8);
+                            throw new PaymentException(PaymentErrorCode.TOSS_STATUS_FETCH_FAILED,
+                                    "status: " + response.getStatusCode().value() + ", body: " + body);
+                        }
+                )
                 .body(TossPaymentStatusResponse.class);
     }
 
@@ -65,6 +73,14 @@ public class TossPaymentClient {
         return tossRestClient.get()
                 .uri("/v1/payments/{paymentKey}", paymentKey)
                 .retrieve()
+                .onStatus(
+                        status -> !status.is2xxSuccessful(),
+                        (request, response) -> {
+                            String body = new String(response.getBody().readAllBytes(), StandardCharsets.UTF_8);
+                            throw new PaymentException(PaymentErrorCode.TOSS_STATUS_FETCH_FAILED,
+                                    "status: " + response.getStatusCode().value() + ", body: " + body);
+                        }
+                )
                 .body(TossPaymentStatusResponse.class);
     }
 }

--- a/src/main/java/org/ticketing/payment/infrastructure/toss/TossPaymentProviderImpl.java
+++ b/src/main/java/org/ticketing/payment/infrastructure/toss/TossPaymentProviderImpl.java
@@ -1,8 +1,11 @@
 package org.ticketing.payment.infrastructure.toss;
 
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
+import org.ticketing.payment.domain.exception.PaymentErrorCode;
+import org.ticketing.payment.domain.exception.PaymentException;
 import org.ticketing.payment.domain.provider.TossPaymentProvider;
 import org.ticketing.payment.infrastructure.toss.dto.TossConfirmResponse;
 import org.ticketing.payment.infrastructure.toss.dto.TossPaymentStatusResponse;
@@ -12,9 +15,12 @@ import org.ticketing.payment.infrastructure.toss.dto.TossPaymentStatusResponse;
 @RequiredArgsConstructor
 public class TossPaymentProviderImpl implements TossPaymentProvider {
 
+    private static final String CIRCUIT_BREAKER_NAME = "toss";
+
     private final TossPaymentClient tossPaymentClient;
 
     @Override
+    @CircuitBreaker(name = CIRCUIT_BREAKER_NAME, fallbackMethod = "confirmFallback")
     public ConfirmResult confirm(String paymentKey, String orderId, Long amount) {
         TossConfirmResponse response = tossPaymentClient.confirm(paymentKey, orderId, amount);
         return new ConfirmResult(
@@ -26,11 +32,13 @@ public class TossPaymentProviderImpl implements TossPaymentProvider {
     }
 
     @Override
+    @CircuitBreaker(name = CIRCUIT_BREAKER_NAME, fallbackMethod = "cancelFallback")
     public void cancel(String paymentKey, String cancelReason) {
         tossPaymentClient.cancel(paymentKey, cancelReason);
     }
 
     @Override
+    @CircuitBreaker(name = CIRCUIT_BREAKER_NAME, fallbackMethod = "getByOrderIdFallback")
     public StatusResult getByOrderId(String orderId) {
         TossPaymentStatusResponse response = tossPaymentClient.getByOrderId(orderId);
         return new StatusResult(
@@ -42,6 +50,7 @@ public class TossPaymentProviderImpl implements TossPaymentProvider {
     }
 
     @Override
+    @CircuitBreaker(name = CIRCUIT_BREAKER_NAME, fallbackMethod = "getByPaymentKeyFallback")
     public StatusResult getByPaymentKey(String paymentKey) {
         TossPaymentStatusResponse response = tossPaymentClient.getByPaymentKey(paymentKey);
         return new StatusResult(
@@ -50,5 +59,21 @@ public class TossPaymentProviderImpl implements TossPaymentProvider {
                 response.getStatus(),
                 response.getTotalAmount()
         );
+    }
+
+    private ConfirmResult confirmFallback(String paymentKey, String orderId, Long amount, Throwable t) {
+        throw new PaymentException(PaymentErrorCode.TOSS_CONFIRM_FAILED, "PG 일시 장애: " + t.getMessage());
+    }
+
+    private void cancelFallback(String paymentKey, String cancelReason, Throwable t) {
+        throw new PaymentException(PaymentErrorCode.TOSS_CANCEL_FAILED, "PG 일시 장애: " + t.getMessage());
+    }
+
+    private StatusResult getByOrderIdFallback(String orderId, Throwable t) {
+        throw new PaymentException(PaymentErrorCode.TOSS_STATUS_FETCH_FAILED, "PG 일시 장애: " + t.getMessage());
+    }
+
+    private StatusResult getByPaymentKeyFallback(String paymentKey, Throwable t) {
+        throw new PaymentException(PaymentErrorCode.TOSS_STATUS_FETCH_FAILED, "PG 일시 장애: " + t.getMessage());
     }
 }

--- a/src/main/java/org/ticketing/payment/presentation/controller/PaymentInternalController.java
+++ b/src/main/java/org/ticketing/payment/presentation/controller/PaymentInternalController.java
@@ -48,4 +48,10 @@ public class PaymentInternalController {
     public PaymentResponseDto getSuccessPaymentByReservationId(@PathVariable @NotNull UUID reservationId) {
         return PaymentResponseDto.from(paymentService.getSuccessPaymentByReservationId(reservationId));
     }
+
+    // reservationId에 따른 가장 최근 결제 시도 1건 조회 (상태 무관)
+    @GetMapping("/reservations/{reservationId}/latest")
+    public PaymentResponseDto getLatestPaymentByReservationId(@PathVariable @NotNull UUID reservationId) {
+        return PaymentResponseDto.from(paymentService.getLatestPaymentByReservationId(reservationId));
+    }
 }

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -41,6 +41,10 @@ eureka:
 toss:
   secret-key: ${TOSS_SECRET_KEY}
 
+feign:
+  circuitbreaker:
+    enabled: true
+
 resilience4j:
   circuitbreaker:
     instances:

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -40,3 +40,13 @@ eureka:
 
 toss:
   secret-key: ${TOSS_SECRET_KEY}
+
+resilience4j:
+  circuitbreaker:
+    instances:
+      toss:
+        sliding-window-size: 10                      # 최근 10건 기준으로 실패율 계산
+        failure-rate-threshold: 50                   # 50% 이상 실패 → OPEN
+        wait-duration-in-open-state: 10s             # 10초 대기 후 HALF-OPEN 전환
+        permitted-number-of-calls-in-half-open-state: 3  # HALF-OPEN에서 3건 시도 후 판단
+        register-health-indicator: true


### PR DESCRIPTION
## Description

### 📎 관련 이슈
- close #이슈번호

### 📌 작업 내용
- `TossPaymentClient`에서 매 요청마다 `RestClient`를 새로 생성하던 방식을 제거하고, `TossRestClientConfig`에서 싱글톤 빈으로 분리
- Toss API 호출에 커넥션 타임아웃(3s) / 읽기 타임아웃(10s) 설정 추가
- Base64 인코딩된 Authorization 헤더를 빈 생성 시점에 한 번만 처리하도록 개선
- `TossPaymentProviderImpl`의 전체 메서드에 Resilience4j `@CircuitBreaker` 적용
- `MockTossPaymentProvider`에도 동일한 Circuit Breaker 적용 (테스트 환경 일관성 확보)
- `ReservationFeignClient`에 Feign Circuit Breaker fallback(`ReservationClientFallback`) 연결
- `TOSS_STATUS_FETCH_FAILED`, `RESERVATION_SERVICE_UNAVAILABLE` 에러코드 추가

### 🧠 기타 참고 사항
- Resilience4j 의존성: `spring-cloud-starter-circuitbreaker-resilience4j`
- Feign Circuit Breaker 활성화: `feign.circuitbreaker.enabled: true` **<- config-repo도 업데이트 필요**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added circuit breakers and fallback handlers on payment/reservation calls.
  * Exposed new internal endpoint to fetch the latest payment by reservation ID.

* **Configuration**
  * Added Resilience4j dependency, circuit-breaker settings, and HTTP client timeouts.

* **Stability**
  * Added a fallback implementation for reservation lookups and circuit-breaker-aware mock/payment providers.

* **Data**
  * Added repository and service methods to retrieve the most recent payment for a reservation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/3s-ticketing/payment-service/pull/33)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->