### PR TITLE
chore: payment-service 다중 EC2 순차 배포 적용

### DIFF
--- a/.github/workflows/payment-service-deploy.yml
+++ b/.github/workflows/payment-service-deploy.yml
@@ -56,7 +56,7 @@ jobs:
           docker push $REGISTRY/$IMAGE_NAME:$IMAGE_TAG
           docker push $REGISTRY/$IMAGE_NAME:${{ github.sha }}
 
-      - name: Deploy payment-service to EC2
+      - name: Deploy payment-service to main-1 EC2
         uses: appleboy/ssh-action@v1.0.3
         with:
           host: ${{ secrets.EC2_HOST }}
@@ -64,8 +64,76 @@ jobs:
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
             echo "${{ secrets.GPR_TOKEN }}" | docker login ghcr.io -u ${{ secrets.GPR_USER }} --password-stdin
+
             cd ~/deploy/ticketing/ticketing-system
+
+            git fetch origin
+            git reset --hard origin/dev
+
             docker compose -f docker-compose.app.yml pull payment-service
             docker compose -f docker-compose.app.yml up -d --no-deps --force-recreate payment-service
-            docker ps --filter "name=ticketing-payment-service"
+
+            for i in {1..30}; do
+              if curl -fsS http://localhost:20006/actuator/health > /dev/null; then
+                echo "payment-service on main-1 is healthy"
+                docker ps --filter "name=ticketing-payment-service"
+                exit 0
+              fi
+
+              echo "Waiting for payment-service on main-1... ($i/30)"
+              sleep 3
+            done
+
+            echo "payment-service health check failed on main-1"
+            docker logs --tail=100 ticketing-payment-service
+            exit 1
+
+      - name: Deploy payment-service to main-2 EC2
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.EC2_HOST_2 }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            echo "${{ secrets.GPR_TOKEN }}" | docker login ghcr.io -u ${{ secrets.GPR_USER }} --password-stdin
+
+            cd ~/deploy/ticketing/ticketing-system
+
+            git fetch origin
+            git reset --hard origin/dev
+
+            docker compose -f docker-compose.app.yml pull payment-service
+            docker compose -f docker-compose.app.yml up -d --no-deps --force-recreate payment-service
+
+            for i in {1..30}; do
+              if curl -fsS http://localhost:20006/actuator/health > /dev/null; then
+                echo "payment-service on main-2 is healthy"
+                docker ps --filter "name=ticketing-payment-service"
+                exit 0
+              fi
+
+              echo "Waiting for payment-service on main-2... ($i/30)"
+              sleep 3
+            done
+
+            echo "payment-service health check failed on main-2"
+            docker logs --tail=100 ticketing-payment-service
+            exit 1
+
+      - name: Prune Docker images on main-1 EC2
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            docker image prune -f
+
+      - name: Prune Docker images on main-2 EC2
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.EC2_HOST_2 }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
             docker image prune -f


### PR DESCRIPTION
### 📎 관련 이슈
- close #39 

### 📌 작업 내용
- `payment-service` CD workflow의 배포 대상을 기존 단일 EC2에서 main-1, main-2 EC2 2대로 확장했습니다.
- main-1 배포 및 health check 성공 후 main-2를 배포하도록 순차 배포 구조를 적용했습니다.
- 각 EC2에서 최신 `ticketing-system` compose 설정을 반영한 뒤 `payment-service` 컨테이너를 재생성하도록 구성했습니다.

### ✨ 변경 사항
- `Deploy payment-service to main-1 EC2` step 추가
- `Deploy payment-service to main-2 EC2` step 추가
- 각 서버 배포 후 `http://localhost:20006/actuator/health` 기반 health check 추가
- main-1, main-2 각각 Docker image prune 수행
- 기존 GHCR image build/push 방식은 유지

### 📝 리뷰 포인트 (선택)
- `EC2_HOST_2` GitHub Actions Secret이 추가되어 있어야 정상 동작합니다.
- 배포는 main-1 → main-2 순서로 진행됩니다.
- main-1 배포 또는 health check가 실패하면 main-2 배포로 넘어가지 않도록 구성했습니다.
- user-service에서 검증한 다중 EC2 순차 배포 패턴을 payment-service에 동일하게 적용했습니다.

### 🧠 기타 참고 사항
- 기존 `EC2_HOST`는 main-1 EC2를 의미합니다.
- `EC2_HOST_2`는 main-2 EC2를 의미합니다.
- ALB 뒤의 두 애플리케이션 서버가 동일한 `payment-service` 버전을 실행하도록 배포 흐름을 정리했습니다.